### PR TITLE
Braille Translator - Saeid Alizadeh

### DIFF
--- a/go/translator.go
+++ b/go/translator.go
@@ -6,7 +6,7 @@ There are certain assumptions for the logic
 Assumptions
     1. ONLY braille inputs start with "."
     2. If input braille, it will ONLY be one input
-
+    3. Symbols `<`, `>`, `)`, and `(` have been ignored
 */
 
 package main
@@ -148,13 +148,6 @@ var brailleToEnglishAlphMap = map[string]string{
 }
 
 func translateToEnglish(brailleStatement string) string {
-	// braille statement chars are ASCII. so if we
-	// iterate over the string, we get the correct rune
-
-	sbRes := strings.Builder{}
-	var makeCap bool
-	var isNumber bool
-
 	// more efficient way for string concatenation
 	// it prevents copying the string over and over
 	// with every iteration, especially her that we know
@@ -163,7 +156,13 @@ func translateToEnglish(brailleStatement string) string {
 	sb := strings.Builder{}
 	sb.Grow(maxBrailleChars)
 
+    sbRes := strings.Builder{}
+	var makeCap bool
+	var isNumber bool
+
 mainLoop:
+	// braille statement chars are ASCII. so if we
+	// iterate over the string, we get the correct rune
 	for i, c := range brailleStatement {
 		sb.WriteRune(c)
 
@@ -302,8 +301,3 @@ func main() {
 		fmt.Println(translateToBraille(concatedWords))
 	}
 }
-
-/*
-.....OO.....O.O...OO...........O.OOOO.O...OO....OO.O........OO..OO.....OOO.OOOO..OOO
-.....OO.....O.O...OO....
-*/

--- a/go/translator.go
+++ b/go/translator.go
@@ -1,1 +1,151 @@
 package main
+
+import (
+	"os"
+	"strings"
+)
+
+const (
+	CapitalFollows uint8 = iota
+	DecimalFollows
+	NumberFollows
+)
+
+var FollowsMap = map[string]uint8{
+	".....O": CapitalFollows,
+	".O...O": DecimalFollows,
+	".O.OOO": NumberFollows,
+}
+
+var englishToBrailleMap = map[rune]string{
+	'a': "O.....",
+	'b': "O.O...",
+	'c': "OO....",
+	'd': "OO.O..",
+	'e': "O..O..",
+	'f': "OOO...",
+	'g': "OOOO..",
+	'h': "O.OO..",
+	'i': ".OO...",
+	'j': ".OOO..",
+	'k': "O...O.",
+	'l': "O.O.O.",
+	'm': "OO..O.",
+	'n': "OO.OO.",
+	'o': "O..OO.",
+	'p': "OOO.O.",
+	'q': "OOOOO.",
+	'r': "O.OOO.",
+	's': ".OO.O.",
+	't': ".OOOO.",
+	'u': "O...OO",
+	'v': "O.O.OO",
+	'w': ".OOO.O",
+	'x': "OO..OO",
+	'y': "OO.OOO",
+	'z': "O..OOO",
+	'1': "O.....",
+	'2': "O.O...",
+	'3': "OO....",
+	'4': "OO.O..",
+	'5': "O..O..",
+	'6': "OOO...",
+	'7': "OOOO..",
+	'8': "O.OO..",
+	'9': ".OO...",
+	'0': ".OOO..",
+	'.': "..OO.O",
+	',': "..O...",
+	'?': "..O.OO",
+	'!': "..OOO.",
+	':': "..OO..",
+	';': "..O.O.",
+	'-': "....OO",
+	'/': ".O..O.",
+	'<': ".OO..O",
+	'>': "O..OO.",
+	'(': "O.O..O",
+	')': ".O.OO.",
+	' ': "......",
+}
+
+var brailleToEnglishNumMap = map[string]rune{
+	"O.....": '1',
+	"O.O...": '2',
+	"OO....": '3',
+	"OO.O..": '4',
+	"O..O..": '5',
+	"OOO...": '6',
+	"OOOO..": '7',
+	"O.OO..": '8',
+	".OO...": '9',
+	".OOO..": '0',
+}
+
+var brailleToEnglishAlphMap = map[string]rune{
+	"O.....": 'a',
+	"O.O...": 'b',
+	"OO....": 'c',
+	"OO.O..": 'd',
+	"O..O..": 'e',
+	"OOO...": 'f',
+	"OOOO..": 'g',
+	"O.OO..": 'h',
+	".OO...": 'i',
+	".OOO..": 'j',
+	"O...O.": 'k',
+	"O.O.O.": 'l',
+	"OO..O.": 'm',
+	"OO.OO.": 'n',
+	"O..OO.": 'o',
+	"OOO.O.": 'p',
+	"OOOOO.": 'q',
+	"O.OOO.": 'r',
+	".OO.O.": 's',
+	".OOOO.": 't',
+	"O...OO": 'u',
+	"O.O.OO": 'v',
+	".OOO.O": 'w',
+	"OO..OO": 'x',
+	"OO.OOO": 'y',
+	"O..OOO": 'z',
+	"..OO.O": '.',
+	"..O...": ',',
+	"..O.OO": '?',
+	"..OOO.": '!',
+	"..OO..": ':',
+	"..O.O.": ';',
+	"....OO": '-',
+	".O..O.": '/',
+	// ".OO..O": '<',
+	// "O..OO.": '>',
+	"O.O..O": '(',
+	".O.OO.": ')',
+	"......": ' ',
+}
+
+func translateToEnglish(brailleStatement string) {
+
+}
+
+func translateToBraille(englishWords []string) {
+
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		panic("must provide arguments to cli")
+	}
+
+	/*
+		Assumptions
+		    1. ONLY braille inputs start with .
+		    2. It will ONLY be one braille input
+	*/
+	if len(os.Args) == 2 && strings.HasPrefix(os.Args[1], ".") {
+		translateToEnglish(os.Args[1])
+
+	} else {
+		translateToBraille(os.Args[1:])
+	}
+}

--- a/go/translator.go
+++ b/go/translator.go
@@ -4,9 +4,8 @@ English and vice versa.
 
 There are certain assumptions for the logic
 Assumptions
-    1. ONLY braille inputs start with "."
-    2. If input braille, it will ONLY be one input
-    3. Symbols `<`, `>`, `)`, and `(` have been ignored
+    1. If input braille, it will ONLY be one input
+    2. Symbols `<`, `>`, `)`, and `(` have been ignored
 */
 
 package main

--- a/go/translator.go
+++ b/go/translator.go
@@ -222,11 +222,29 @@ func concatString(words []string) string {
 func translateToBraille(concatedWords string) string {
 	sb := strings.Builder{}
 	sb.Grow(maxBrailleChars) // there will at least one english char
+	writeNumberFollow := true
 
 	for _, engRune := range concatedWords {
 		if unicode.IsUpper(engRune) {
 			sb.WriteString(CapitalFollowsBraille)
 			engRune = unicode.ToLower(engRune)
+		}
+
+		// If it's the first occurrence of a number
+		// FollowNumber prefix must be added before
+		// numbers sequence
+		if unicode.IsNumber(engRune) {
+			if writeNumberFollow {
+				sb.WriteString(NumberFollowsBraille)
+				writeNumberFollow = false
+			}
+		}
+
+		// existence of space means the end of numbers
+		// sequence. Setting the flag to true to write the
+		// braille string for the next number seq occurrence
+		if unicode.IsSpace(engRune) {
+			writeNumberFollow = true
 		}
 
 		brailString, prs := englishToBrailleMap[engRune]
@@ -247,12 +265,13 @@ func main() {
 
 	/*
 		Assumptions
-		    1. ONLY braille inputs start with .
-		    2. It will ONLY be one braille input
+		    1. ONLY braille inputs start with "."
+		    2. If input braille, it will ONLY be one input
 	*/
 	if len(os.Args) >= 3 || (len(os.Args) == 2 && !strings.HasPrefix(os.Args[1], ".")) {
 		concatedWords := concatString(os.Args[1:])
 		fmt.Println(translateToBraille(concatedWords))
+        return
 	}
 
 	fmt.Println(translateToEnglish(os.Args[1]))

--- a/go/translator.go
+++ b/go/translator.go
@@ -184,7 +184,9 @@ mainLoop:
 					continue mainLoop
 
 				case DecimalFollowsAction:
-					// pass
+					sbRes.WriteString(".")
+                    sb.Reset()
+                    continue mainLoop
 				}
 			}
 

--- a/go/translator.go
+++ b/go/translator.go
@@ -280,16 +280,30 @@ func translateToBraille(concatedWords string) string {
 	return sb.String()
 }
 
+func isInputBraille(firstArg string) bool {
+	for _, char := range firstArg {
+		if char != 'O' && char != '.' {
+			return false
+		}
+	}
+
+	return true
+}
+
 func main() {
 	if len(os.Args) < 2 {
 		panic("must provide arguments to cli")
 	}
 
-	if len(os.Args) >= 3 || (len(os.Args) == 2 && !strings.HasPrefix(os.Args[1], ".")) {
+	if isInputBraille(os.Args[1]) {
+		fmt.Println(translateToEnglish(os.Args[1]))
+	} else {
 		concatedWords := concatString(os.Args[1:])
 		fmt.Println(translateToBraille(concatedWords))
-		return
 	}
-
-	fmt.Println(translateToEnglish(os.Args[1]))
 }
+
+/*
+.....OO.....O.O...OO...........O.OOOO.O...OO....OO.O........OO..OO.....OOO.OOOO..OOO
+.....OO.....O.O...OO....
+*/

--- a/go/translator.go
+++ b/go/translator.go
@@ -1,3 +1,14 @@
+/*
+This package will handle the translation of braille string to
+English and vice versa.
+
+There are certain assumptions for the logic
+Assumptions
+    1. ONLY braille inputs start with "."
+    2. If input braille, it will ONLY be one input
+
+*/
+
 package main
 
 import (
@@ -240,6 +251,13 @@ func translateToBraille(concatedWords string) string {
 			}
 		}
 
+		// If this is the case, we're still writing numbers and "."
+		// does not represent period rather a decimcal point
+		if !writeNumberFollow && string(engRune) == "." {
+			sb.WriteString(DecimalFollowsBraille)
+			continue
+		}
+
 		// existence of space means the end of numbers
 		// sequence. Setting the flag to true to write the
 		// braille string for the next number seq occurrence
@@ -263,15 +281,10 @@ func main() {
 		panic("must provide arguments to cli")
 	}
 
-	/*
-		Assumptions
-		    1. ONLY braille inputs start with "."
-		    2. If input braille, it will ONLY be one input
-	*/
 	if len(os.Args) >= 3 || (len(os.Args) == 2 && !strings.HasPrefix(os.Args[1], ".")) {
 		concatedWords := concatString(os.Args[1:])
 		fmt.Println(translateToBraille(concatedWords))
-        return
+		return
 	}
 
 	fmt.Println(translateToEnglish(os.Args[1]))

--- a/go/translator.go
+++ b/go/translator.go
@@ -23,21 +23,21 @@ const (
 )
 
 const (
-	CapitalFollowsBraille string = ".....O"
-	DecimalFollowsBraille string = ".O...O"
-	NumberFollowsBraille  string = ".O.OOO"
+	capitalFollowsBraille string = ".....O"
+	decimalFollowsBraille string = ".O...O"
+	numberFollowsBraille  string = ".O.OOO"
 )
 
 const (
-	CapitalFollowsAction uint8 = iota
-	DecimalFollowsAction
-	NumberFollowsAction
+	capitalFollowsAction uint8 = iota
+	decimalFollowsAction
+	numberFollowsAction
 )
 
-var FollowActionsMap = map[string]uint8{
-	CapitalFollowsBraille: CapitalFollowsAction,
-	DecimalFollowsBraille: DecimalFollowsAction,
-	NumberFollowsBraille:  NumberFollowsAction,
+var followActionsMap = map[string]uint8{
+	capitalFollowsBraille: capitalFollowsAction,
+	decimalFollowsBraille: decimalFollowsAction,
+	numberFollowsBraille:  numberFollowsAction,
 }
 
 var englishToBrailleMap = map[rune]string{
@@ -85,8 +85,8 @@ var englishToBrailleMap = map[rune]string{
 	';': "..O.O.",
 	'-': "....OO",
 	'/': ".O..O.",
-	'<': ".OO..O",
-	'>': "O..OO.",
+	// '<': ".OO..O",
+	// '>': "O..OO.",
 	'(': "O.O..O",
 	')': ".O.OO.",
 	' ': "......",
@@ -170,23 +170,23 @@ mainLoop:
 		if (i+1)%maxBrailleChars == 0 {
 			singleBraille := sb.String()
 
-			followAction, prs := FollowActionsMap[singleBraille]
+			followAction, prs := followActionsMap[singleBraille]
 			if prs {
 				switch followAction {
-				case NumberFollowsAction:
+				case numberFollowsAction:
 					isNumber = true
 					sb.Reset()
 					continue mainLoop
 
-				case CapitalFollowsAction:
+				case capitalFollowsAction:
 					makeCap = true
 					sb.Reset()
 					continue mainLoop
 
-				case DecimalFollowsAction:
+				case decimalFollowsAction:
 					sbRes.WriteString(".")
-                    sb.Reset()
-                    continue mainLoop
+					sb.Reset()
+					continue mainLoop
 				}
 			}
 
@@ -219,6 +219,8 @@ mainLoop:
 	return sbRes.String()
 }
 
+// Concatenates all the words together
+// and puts a space between them.
 func concatString(words []string) string {
 	sb := strings.Builder{}
 	for i, word := range words {
@@ -239,7 +241,7 @@ func translateToBraille(concatedWords string) string {
 
 	for _, engRune := range concatedWords {
 		if unicode.IsUpper(engRune) {
-			sb.WriteString(CapitalFollowsBraille)
+			sb.WriteString(capitalFollowsBraille)
 			engRune = unicode.ToLower(engRune)
 		}
 
@@ -248,7 +250,7 @@ func translateToBraille(concatedWords string) string {
 		// numbers sequence
 		if unicode.IsNumber(engRune) {
 			if writeNumberFollow {
-				sb.WriteString(NumberFollowsBraille)
+				sb.WriteString(numberFollowsBraille)
 				writeNumberFollow = false
 			}
 		}
@@ -256,7 +258,7 @@ func translateToBraille(concatedWords string) string {
 		// If this is the case, we're still writing numbers and "."
 		// does not represent period rather a decimcal point
 		if !writeNumberFollow && string(engRune) == "." {
-			sb.WriteString(DecimalFollowsBraille)
+			sb.WriteString(decimalFollowsBraille)
 			continue
 		}
 

--- a/go/translator.go
+++ b/go/translator.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strings"
+)
+
+const (
+	maxBrailleChars = 6
 )
 
 const (
@@ -69,63 +74,96 @@ var englishToBrailleMap = map[rune]string{
 	' ': "......",
 }
 
-var brailleToEnglishNumMap = map[string]rune{
-	"O.....": '1',
-	"O.O...": '2',
-	"OO....": '3',
-	"OO.O..": '4',
-	"O..O..": '5',
-	"OOO...": '6',
-	"OOOO..": '7',
-	"O.OO..": '8',
-	".OO...": '9',
-	".OOO..": '0',
+var brailleToEnglishNumMap = map[string]string{
+	"O.....": "1",
+	"O.O...": "2",
+	"OO....": "3",
+	"OO.O..": "4",
+	"O..O..": "5",
+	"OOO...": "6",
+	"OOOO..": "7",
+	"O.OO..": "8",
+	".OO...": "9",
+	".OOO..": "0",
 }
 
-var brailleToEnglishAlphMap = map[string]rune{
-	"O.....": 'a',
-	"O.O...": 'b',
-	"OO....": 'c',
-	"OO.O..": 'd',
-	"O..O..": 'e',
-	"OOO...": 'f',
-	"OOOO..": 'g',
-	"O.OO..": 'h',
-	".OO...": 'i',
-	".OOO..": 'j',
-	"O...O.": 'k',
-	"O.O.O.": 'l',
-	"OO..O.": 'm',
-	"OO.OO.": 'n',
-	"O..OO.": 'o',
-	"OOO.O.": 'p',
-	"OOOOO.": 'q',
-	"O.OOO.": 'r',
-	".OO.O.": 's',
-	".OOOO.": 't',
-	"O...OO": 'u',
-	"O.O.OO": 'v',
-	".OOO.O": 'w',
-	"OO..OO": 'x',
-	"OO.OOO": 'y',
-	"O..OOO": 'z',
-	"..OO.O": '.',
-	"..O...": ',',
-	"..O.OO": '?',
-	"..OOO.": '!',
-	"..OO..": ':',
-	"..O.O.": ';',
-	"....OO": '-',
-	".O..O.": '/',
-	// ".OO..O": '<',
-	// "O..OO.": '>',
-	"O.O..O": '(',
-	".O.OO.": ')',
-	"......": ' ',
+var brailleToEnglishAlphMap = map[string]string{
+	"O.....": "a",
+	"O.O...": "b",
+	"OO....": "c",
+	"OO.O..": "d",
+	"O..O..": "e",
+	"OOO...": "f",
+	"OOOO..": "g",
+	"O.OO..": "h",
+	".OO...": "i",
+	".OOO..": "j",
+	"O...O.": "k",
+	"O.O.O.": "l",
+	"OO..O.": "m",
+	"OO.OO.": "n",
+	"O..OO.": "o",
+	"OOO.O.": "p",
+	"OOOOO.": "q",
+	"O.OOO.": "r",
+	".OO.O.": "s",
+	".OOOO.": "t",
+	"O...OO": "u",
+	"O.O.OO": "v",
+	".OOO.O": "w",
+	"OO..OO": "x",
+	"OO.OOO": "y",
+	"O..OOO": "z",
+	"..OO.O": ".",
+	"..O...": ",",
+	"..O.OO": "?",
+	"..OOO.": "!",
+	"..OO..": ":",
+	"..O.O.": ";",
+	"....OO": "-",
+	".O..O.": "/",
+	// ".OO..O": "<",
+	// "O..OO.": ">",
+	"O.O..O": "(",
+	".O.OO.": ")",
+	"......": " ",
 }
 
-func translateToEnglish(brailleStatement string) {
+func translateToEnglish(brailleStatement string) string {
+	// braille statement chars are ASCII. so if we
+	// iterate over the string, we get the correct rune
+    sbRes := strings.Builder{}
 
+	sb := strings.Builder{}
+	sb.Grow(maxBrailleChars)
+
+	for i, c := range brailleStatement {
+		sb.WriteRune(c)
+
+		if (i+1)%maxBrailleChars == 0 {
+			singleBraille := sb.String()
+
+			// followAction, prs := FollowsMap[singleBraille]
+			// if prs {
+			// 	switch followAction {
+			// 	case NumberFollows:
+
+			// 	}
+			// }
+
+			englishString, prs := brailleToEnglishAlphMap[singleBraille]
+			if !prs {
+				fmt.Println("does not exist!")
+				os.Exit(0)
+			}
+
+            sbRes.WriteString(englishString)
+			sb.Reset()
+			continue
+		}
+	}
+
+    return sbRes.String()
 }
 
 func translateToBraille(englishWords []string) {
@@ -142,10 +180,9 @@ func main() {
 		    1. ONLY braille inputs start with .
 		    2. It will ONLY be one braille input
 	*/
-	if len(os.Args) == 2 && strings.HasPrefix(os.Args[1], ".") {
-		translateToEnglish(os.Args[1])
-
-	} else {
+	if len(os.Args) >= 3 || (len(os.Args) == 2 && !strings.HasPrefix(os.Args[1], ".")) {
 		translateToBraille(os.Args[1:])
 	}
+
+	fmt.Println(translateToEnglish(os.Args[1]))
 }

--- a/go/translator_test.go
+++ b/go/translator_test.go
@@ -15,7 +15,10 @@ func TestSolutionOutput(t *testing.T) {
 
 	// Trim space from output and expected value
 	output := strings.TrimSpace(string(outputBytes))
-	expected := strings.TrimSpace(".....OO.....O.O...OO...........O.OOOO.O...OO....OO.O........OO..OO.....OOO.OOOO..OOO")
+
+	// ! Replace the expected string
+	expected := strings.TrimSpace(".....OO.....O.O...OO...........O.OOOO.....O.O...OO..........OO..OO.....OOO.OOOO..OOO")
+	// expected := strings.TrimSpace(".....OO.....O.O...OO...........O.OOOO.O...OO....OO.O........OO..OO.....OOO.OOOO..OOO")
 
 	if output != expected {
 		t.Errorf("Unexpected output, got: %q, want: %q", output, expected)


### PR DESCRIPTION
# Overview

This PR introduces a Braille translator, which can convert English input arguments to Braille and vice versa. The translator is capable of handling both inputs of numbers and text within the limitation of a specific set of assumptions about Braille representation.

# Technical Features

## Assumptions:
- Braille Input: If the input is Braille, it should be provided as a single string.
- Ignored Symbols: The symbols `<`, `>`, `(`, and `)` are not translated and are currently ignored -> see: #3.

## Efficient String Handling:
- The implementation uses `strings.Builder` to optimize string concatenation for better performance when translating longer texts.

# Usage

You can use the translator from the command line. Depending on whether the input is Braille or English, the corresponding translation will be performed.

Assuming you're in `go` directory:
- English to Braille:
```bash
go run translator.go Hello Great World
```

- Braille to English:
```bash
go run translator.go .....OO.....O.O...OO...........O.OOOO.....O.O...OO..........OO..OO.....OOO.OOOO..OOO
```

# Test Fixes:
This PR also includes fixes to the existing test file, resolving the issues outlined in issue #6.
# Test

```bash
cd go
go test
```