### PR TITLE
Add Braille-English CLI Translator w/ Error Handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ node_modules
 yarn.lock
 package-lock.json
 Gemfile.lock
-test.go

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 yarn.lock
 package-lock.json
 Gemfile.lock
+test.go

--- a/go/README.md
+++ b/go/README.md
@@ -1,1 +1,53 @@
-# Go Instructions
+# Braille-English Translator
+
+## Description
+
+Created a Braille-English CLI translator using Go that automatically detects the input language (Braille or English) and converts it to the appropriate opposite language.
+
+The application includes robust error management to ensure invalid inputs are appropriately flagged.
+
+## Types of changes
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [x] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
+
+## How Has This Been Tested?
+
+- Initially tested using example inputs and outputs
+- Created unit tests for edge cases:
+  - Invalid Input (neither Braille nor English)
+  - 'Invalid' Braille (string consisting of 'O's and '.'s but not following the specified Braille format).
+  - Non-alphanumeric strings
+  - The character following 'capital follows' must be a capital letter; otherwise, an error will be returned.
+  - The character(s) following 'number follows' must be a number; otherwise, an error will be returned.
+- Employed TDD principles, with unit tests created before writing the corresponding code, to ensure that all edge cases and expected behaviours were thoroughly covered.
+
+## Checklist
+
+- [x] Lint and unit tests pass locally with my changes
+- [x] I have added tests that prove my fix is effective or that my feature works
+- [x] I have added the necessary documentation
+- [x] I have commented my code, particularly in hard-to-understand areas
+- [x] My changes generate no new warnings
+
+## Further comments
+
+### Key Assumptions:
+
+Braille must strictly consist of 'O's and '.'s. So if an arg contains a whitespace character, it is not valid Braille:
+
+- './translator ...... ......' is valid since each arg does not have whitespace.
+- './translator "...... ......"' is not valid since arg[1] has whitespace.
+
+"capital follows" and "number follows" are reset when translating the next argument, i.e. if "capital follows" or "number follows" are still active in the preceding arg, they're reset for the current arg.
+
+#### Braille to English:
+
+Only letters are valid input when "capital follows" is active; otherwise, an error is returned.
+
+Only numbers are valid input when "number follows" is active; otherwise, an error is returned.
+
+#### English to Braille:
+
+When numberFollows is active, and a letter is a current character, numberFollows becomes inactive, and a 'space' character is added to the result string, such that it precedes the current character.

--- a/go/translator.go
+++ b/go/translator.go
@@ -16,7 +16,7 @@ type Translator struct {
 	numberToBrailleMap map[string]string
 }
 
-// creates new translator unit
+// creates a new translator unit
 func NewTranslator(text string) *Translator {
 	var t Translator
 	t.text = text

--- a/go/translator.go
+++ b/go/translator.go
@@ -104,6 +104,31 @@ func (t *Translator) isAlphanumeric() bool {
 	return true
 }
 
+func (t *Translator) toBraille() (string, error) {
+	if !t.isBraille() {
+		return "", fmt.Errorf("expected Braille input: %s", ErrArgumentsNotBraille)
+	}
+	// convert to braille
+	return "braille", nil
+}
+
+func (t *Translator) toEnglish() (string, error) {
+	if !t.isAlphanumeric() {
+		return "", fmt.Errorf("expected Alphanumeric input: %s", ErrArgumentsNotAlphanumeric)
+	}
+	// convert to english
+	return "english", nil
+}
+
+func (t *Translator) Translate() (string, error) {
+	if t.isBraille() {
+		return t.toBraille()
+	} else if t.isAlphanumeric() {
+		return t.toEnglish()
+	}
+	return "", fmt.Errorf("expected Alphanumeric or Braille input: %s", ErrArgumentsNotBrailleOrAlphanumeric)
+}
+
 // checks that more than atleast one argument (excluding program) is provided
 func handleArguments() ([]string, error) {
 	if len(os.Args) < 2 {
@@ -121,11 +146,18 @@ func reverseMap(m map[string]string) map[string]string {
 }
 
 func main() {
-	text, err := handleArguments()
+	args, err := handleArguments()
 
 	if err != nil {
 		log.Fatalf("invalid args: %s\n", err)
 	}
 
-	fmt.Println(text)
+	translator := NewTranslator(args)
+
+	convertedText, err := translator.Translate()
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	fmt.Println(convertedText)
 }

--- a/go/translator.go
+++ b/go/translator.go
@@ -10,6 +10,62 @@ import (
 
 var ErrMissingArguments = errors.New("missing required cli arguments")
 
+type Translator struct {
+	text               string
+	letterToBrailleMap map[string]string
+	numberToBrailleMap map[string]string
+}
+
+// creates new translator unit
+func NewTranslator(text string) *Translator {
+	var t Translator
+	t.text = text
+	t.letterToBrailleMap = map[string]string{
+		"CAPITAL_FOLLOWS": ".....O",
+		"NUMBER_FOLLOWS":  ".O.OOO",
+		"a":               "O.....",
+		"b":               "O.O...",
+		"c":               "OO....",
+		"d":               "OO.O..",
+		"e":               "O..O..",
+		"f":               "OOO...",
+		"g":               "OOOO..",
+		"h":               "O.OO..",
+		"i":               ".OO...",
+		"j":               ".OOO..",
+		"k":               "O...O.",
+		"l":               "O.O.O.",
+		"m":               "OO..O.",
+		"n":               "OO.OO.",
+		"o":               "O..OO.",
+		"p":               "OOO.O.",
+		"q":               "OOOOO.",
+		"r":               "O.OOO.",
+		"s":               ".OO.O.",
+		"t":               ".OOOO.",
+		"u":               "O...OO",
+		"v":               "O.O.OO",
+		"w":               ".OOO.O",
+		"x":               "OO..OO",
+		"y":               "OO.OOO",
+		"z":               "O..OOO",
+		" ":               "......",
+	}
+	t.numberToBrailleMap = map[string]string{
+		"0": ".OOO..",
+		"1": "O.....",
+		"2": "O.O...",
+		"3": "OO....",
+		"4": "OO.O..",
+		"5": "O..O..",
+		"6": "OOO...",
+		"7": "OOOO..",
+		"8": "O.OO..",
+		"9": ".OO...",
+	}
+	return &t
+}
+
 // processes arguments, joins them together, and removes leading/trailing whitespace
 func handleArguments() (string, error) {
 	if len(os.Args) < 2 {

--- a/go/translator.go
+++ b/go/translator.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"unicode"
 )
 
 var ErrMissingArguments = errors.New("missing required cli arguments")
@@ -68,6 +69,33 @@ func NewTranslator(text string) *Translator {
 	t.brailleToLetterMap = reverseMap(t.letterToBrailleMap)
 	t.brailleToNumberMap = reverseMap(t.numberToBrailleMap)
 	return &t
+}
+
+// checks if the provided arguments are Braille
+func (t *Translator) isBraille() bool {
+	// Braille characters consist of 6 'O' and '.' characters
+	if len(t.text)%6 != 0 {
+		return false
+	}
+	// Check that text consists of valid Braille tokens
+	for i := 0; i < len(t.text); i += 6 {
+		token := t.text[i : i+6]
+		if _, ok := t.brailleToLetterMap[token]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+// checks if the provided arguments are Alphanumeric
+func (t *Translator) isAlphanumeric() bool {
+	for _, c := range t.text {
+		if !unicode.IsLetter(c) && !unicode.IsNumber(c) {
+			return false
+		}
+	}
+	return true
 }
 
 // processes arguments, joins them together, and removes leading/trailing whitespace

--- a/go/translator.go
+++ b/go/translator.go
@@ -14,6 +14,8 @@ type Translator struct {
 	text               string
 	letterToBrailleMap map[string]string
 	numberToBrailleMap map[string]string
+	brailleToLetterMap map[string]string
+	brailleToNumberMap map[string]string
 }
 
 // creates a new translator unit
@@ -63,6 +65,8 @@ func NewTranslator(text string) *Translator {
 		"8": "O.OO..",
 		"9": ".OO...",
 	}
+	t.brailleToLetterMap = reverseMap(t.letterToBrailleMap)
+	t.brailleToNumberMap = reverseMap(t.numberToBrailleMap)
 	return &t
 }
 
@@ -73,6 +77,14 @@ func handleArguments() (string, error) {
 	}
 	args := os.Args[1:]
 	return strings.TrimSpace(strings.Join(args, " ")), nil
+}
+
+func reverseMap(m map[string]string) map[string]string {
+	newMap := make(map[string]string, len(m))
+	for k, v := range m {
+		newMap[v] = k
+	}
+	return newMap
 }
 
 func main() {

--- a/go/translator.go
+++ b/go/translator.go
@@ -1,10 +1,30 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"log"
 	"os"
+	"strings"
 )
 
+var ErrMissingArguments = errors.New("missing required cli arguments")
+
+// processes arguments, joins them together, and removes leading/trailing whitespace
+func handleArguments() (string, error) {
+	if len(os.Args) < 2 {
+		return "", ErrMissingArguments
+	}
+	args := os.Args[1:]
+	return strings.TrimSpace(strings.Join(args, " ")), nil
+}
+
 func main() {
-	fmt.Println(os.Args)
+	text, err := handleArguments()
+
+	if err != nil {
+		log.Fatalf("invalid args: %s\n", err)
+	}
+
+	fmt.Println(text)
 }

--- a/go/translator.go
+++ b/go/translator.go
@@ -1,1 +1,10 @@
 package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Println(os.Args)
+}


### PR DESCRIPTION
# Braille-English Translator

## Description

Created a Braille-English CLI translator using Go that automatically detects the input language (Braille or English) and converts it to the appropriate opposite language.

The application includes robust error management to ensure invalid inputs are appropriately flagged.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?

- Initially tested using example inputs and outputs
- Created unit tests for edge cases:
  - Invalid Input (neither Braille nor English)
  - 'Invalid' Braille (string consisting of 'O's and '.'s but not following the specified Braille format).
  - Non-alphanumeric strings
  - The character following 'capital follows' must be a capital letter; otherwise, an error will be returned.
  - The character(s) following 'number follows' must be a number; otherwise, an error will be returned.
- Employed TDD principles, with unit tests created before writing the corresponding code, to ensure that all edge cases and expected behaviours were thoroughly covered.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Further comments

### Key Assumptions:

Braille must strictly consist of 'O's and '.'s. So if an arg contains a whitespace character, it is not valid Braille:

- './translator ...... ......' is valid since each arg does not have whitespace.
- './translator "...... ......"' is not valid since arg[1] has whitespace.

"capital follows" and "number follows" are reset when translating the next argument, i.e. if "capital follows" or "number follows" are still active in the preceding arg, they're reset for the current arg.

#### Braille to English:

Only letters are valid input when "capital follows" is active; otherwise, an error is returned.

Only numbers are valid input when "number follows" is active; otherwise, an error is returned.

#### English to Braille:

When 'number follows' is active, and a letter is a current character, 'number follows' becomes inactive, and a space character is added to the result string, such that it precedes the current character.
