### PR TITLE
Feat: Translate between Braille and English

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,1 +1,11 @@
 # Python Instructions
+
+This is a command-line application to translate text between Braille and English.
+The application can handle both translations and recognizes whether the input text is in Braille or English.
+It supports the entire English alphabet, numbers 0-9, spaces, and capitalization.
+
+## Features
+
+- Translate English to Braille.
+- Translate Braille to English.
+- Handle capitalization and numbers.

--- a/python/README.md
+++ b/python/README.md
@@ -1,11 +1,36 @@
 # Python Instructions
 
-This is a command-line application to translate text between Braille and English.
-The application can handle both translations and recognizes whether the input text is in Braille or English.
-It supports the entire English alphabet, numbers 0-9, spaces, and capitalization.
+# Braille Translator
+
+This is a Python script that translates between English text and Braille. It supports translation of both plain English text (letters, numbers, and some special characters) to Braille and Braille back to English text.
 
 ## Features
 
-- Translate English to Braille.
-- Translate Braille to English.
-- Handle capitalization and numbers.
+- **Bidirectional Translation**: Convert English text to Braille and Braille to English.
+- **Support for Special Symbols**: The script recognizes special symbols such as capital letters, numbers, and punctuation.
+- **Error Handling**: The script logs errors for any formatting issues with the input.
+
+## How It Works
+
+The script defines mappings between plain text (letters, numbers, and some punctuation marks) and Braille representations. When a user inputs a string, the script detects whether it is Braille or plain English and translates it accordingly.
+
+### Mappings
+
+- **Plain Text to Braille**: Letters, numbers, and punctuation are mapped to corresponding Braille representations.
+- **Braille to Plain Text**: Braille characters are mapped back to plain text, with support for capitalization and numbers.
+
+### Special Symbols
+
+The script recognizes certain Braille patterns as special symbols, such as:
+
+- **Capitalization**: Indicated by a Braille pattern before a capital letter.
+- **Numbers**: Indicated by a Braille pattern before a sequence of digits.
+- **Punctuation**: Specific patterns are recognized for common punctuation marks.
+
+## Usage
+
+To run the script, use the following command in your terminal:
+
+```bash
+python translator.py <text to translate>
+```

--- a/python/translator.py
+++ b/python/translator.py
@@ -1,0 +1,196 @@
+import sys
+import logging
+
+# Constants
+
+# Error message format for incorrect input
+FORMAT_ERR = "{input_type} input '{input}' is not formatted correctly."
+
+# Logger setup
+LOGGER = logging.getLogger(__name__)
+
+# Mappings between braille and plain text
+PLAIN_TO_BRAILLE = {
+    "a": "O.....",
+    "b": "O.O...",
+    "c": "OO....",
+    "d": "OO.O..",
+    "e": "O..O..",
+    "f": "OOO...",
+    "g": "OOOO..",
+    "h": "O.OO..",
+    "i": ".OO...",
+    "j": ".OOO..",
+    "k": "O...O.",
+    "l": "O.O.O.",
+    "m": "OO..O.",
+    "n": "OO.OO.",
+    "o": "O..OO.",
+    "p": "OOO.O.",
+    "q": "OOOOO.",
+    "r": "O.OOO.",
+    "s": ".OO.O.",
+    "t": ".OOOO.",
+    "u": "O...OO",
+    "v": "O.O.OO",
+    "w": ".OOO.O",
+    "x": "OO..OO",
+    "y": "OO.OOO",
+    "z": "O..OOO",
+    "1": "O.....",
+    "2": "O.O...",
+    "3": "OO....",
+    "4": "OO.O..",
+    "5": "O..O..",
+    "6": "OOO...",
+    "7": "OOOO..",
+    "8": "O.OO..",
+    "9": ".OO...",
+    "0": ".OOO..",
+    " ": "......",
+    ".": ".O..OO",
+    ",": "..O...",
+    "?": ".OO.OO",
+    "!": "O.OO.O",
+    ":": "OO..OO",
+    ";": "O.O.OO",
+    "-": "O....O",
+    "/": "O...O.",
+    "<": "O..OOO",
+    ">": ".O.OOO",
+    "(": "O..O.O",
+    ")": ".OO..O",
+    " ": "......",
+}
+
+# Reverse mapping from braille to plain text (only for alphabetic characters)
+BRAILLE_TO_ALPHABET = {
+    braille: plain for plain, braille in PLAIN_TO_BRAILLE.items() if not plain.isdigit()
+}
+
+# Reverse mapping from braille to numeric characters
+BRAILLE_TO_NUMBER = {
+    braille: number for number, braille in PLAIN_TO_BRAILLE.items() if number.isdigit()
+}
+
+# Special symbols in braille (capital letter, number sign, etc.)
+SPECIAL_SYMBOLS = {"capital": ".....O", "number": ".O.OOO", "decimal": ".O...O"}
+
+# Reverse mapping for special braille symbols
+SPECIAL_SYMBOLS_BRAILLE = {
+    braille: symbol for symbol, braille in SPECIAL_SYMBOLS.items()
+}
+
+
+def is_braille(text: str) -> bool:
+    """Determine whether the input text is braille or not.
+
+    Args:
+        text: Braille or plain text.
+    """
+    # Check if all characters in text are valid braille characters ('O' or '.')
+    for t in text:
+        if t not in ["O", "."]:
+            return False
+
+    # Ensure the length of the braille text is a multiple of 6 (one braille character)
+    return len(text) % 6 == 0
+
+
+def translate(text):
+    """
+    Translate between Braille and English. Determine the type of text and convert accordingly.
+    """
+    input_type = "Braille" if is_braille(text) else "English"
+
+    try:
+        return (
+            braille_to_english(text) if is_braille(text) else english_to_braille(text)
+        )
+    except KeyError:
+        # Log an error if input text is not formatted correctly
+        LOGGER.error(FORMAT_ERR.format(input_type=input_type, input=text))
+
+
+def braille_to_english(braille):
+    """Translate braille to english.
+
+    Precondition:
+        braille is a valid braille text.
+    """
+    english = ""
+
+    # Flags to track if the next letter should be capitalized or treated as a number
+    is_capital = False
+    is_number = False
+
+    i = 0
+    while i + 6 <= len(braille):
+        # Extract the next braille character (6 dots)
+        bchar = braille[i : i + 6]
+        symbol = SPECIAL_SYMBOLS_BRAILLE.get(bchar, None)
+
+        # Set flags based on special symbols (capital or number)
+        if symbol:
+            if symbol == "capital":
+                is_capital = True
+            elif symbol == "number":
+                is_number = True
+
+            i += 6
+            continue
+
+        alphabets = BRAILLE_TO_ALPHABET
+
+        if alphabets[bchar] == " ":
+            is_number = False
+        elif is_number:
+            alphabets = BRAILLE_TO_NUMBER
+
+        # Add the corresponding English character to the result
+        english += alphabets[bchar].upper() if is_capital else alphabets[bchar]
+
+        # Reset the capital flag and move to the next character
+        is_capital = False
+        i += 6
+
+    return english
+
+
+def english_to_braille(plain):
+    """Translate english to braille.
+
+    Precondition:
+        Input plain is a valid english text.
+    """
+    braille = ""
+    is_digit = False
+
+    for char in plain:
+        # Add special braille symbol for capital letters
+        if char.isupper():
+            braille += SPECIAL_SYMBOLS["capital"]
+        # Add special braille symbol for numbers
+        elif char.isdigit() and not is_digit:
+            braille += SPECIAL_SYMBOLS["number"]
+            is_digit = True
+        # Reset digit flag when encountering a space
+        elif char == " ":
+            is_digit = False
+
+        # Add corresponding braille character to the result
+        braille += PLAIN_TO_BRAILLE[char.lower()]
+
+    return braille
+
+
+if __name__ == "__main__":
+    # Check if there is text provided for translation
+    if len(sys.argv) < 2:
+        print("Usage: python translator.py text to translate")
+        sys.exit(1)
+
+    # Combine all arguments into a single string for translation
+    text_to_translate = " ".join(sys.argv[1:])
+    translated_text = translate(text_to_translate)
+    print(translated_text)


### PR DESCRIPTION
# Braille Translator
This is a Python script that translates between English text and Braille. It supports translation of both plain English text (letters, numbers, and some special characters) to Braille and Braille back to English text.

## Clarification on Test Case Output
Regarding the test cases, I’ve observed that according to the `expected_output` in `translator.test.py`, one of the test cases appears to be expecting '234' instead of '123'. My code and command line examples function as expected, but due to this discrepancy, the tests are not passing. I understand that the test files should remain unaltered, so I wanted to bring this to your attention for your awareness.