### PR TITLE
Implement bi-directional braille-english translations (Richard Zhang)

### DIFF
--- a/go/benchmark_test.go
+++ b/go/benchmark_test.go
@@ -1,0 +1,14 @@
+package main
+
+import "testing"
+
+func BenchmarkEToBSolution(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		EnglishToBrailleTranslator("Abc 123 xYz")
+	}
+}
+func BenchmarkBToESolution(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		BrailleToEnglishTranslator(".....OO.....O.O...OO...........O.OOOO.....O.O...OO..........OO..OO.....OOO.OOOO..OOO")
+	}
+}

--- a/go/benchmark_test.go
+++ b/go/benchmark_test.go
@@ -4,11 +4,11 @@ import "testing"
 
 func BenchmarkEToBSolution(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		EnglishToBrailleTranslator("Abc 123 xYz")
+		EnglishToBraille("Abc 123 xYz")
 	}
 }
 func BenchmarkBToESolution(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		BrailleToEnglishTranslator(".....OO.....O.O...OO...........O.OOOO.....O.O...OO..........OO..OO.....OOO.OOOO..OOO")
+		BrailleToEnglish(".....OO.....O.O...OO...........O.OOOO.....O.O...OO..........OO..OO.....OOO.OOOO..OOO")
 	}
 }

--- a/go/translator.go
+++ b/go/translator.go
@@ -26,9 +26,9 @@ func main() {
 	var result string
 	var err error
 	if isEnglish {
-		result, err = EnglishToBrailleTranslator(input)
+		result, err = EnglishToBraille(input)
 	} else {
-		result, err = BrailleToEnglishTranslator(input)
+		result, err = BrailleToEnglish(input)
 	}
 	if err != nil {
 		log.Fatal(err)
@@ -51,9 +51,9 @@ func IsEnglish(input string) bool {
 	return false
 }
 
-// EnglishToBrailleTranslator is a function that returns a converted Braille string from an English string
+// EnglishToBraille is a function that returns a converted Braille string from an English string
 // As per Readme, only handles characters and numbers not including decimal and special symbols
-func EnglishToBrailleTranslator(input string) (string, error) {
+func EnglishToBraille(input string) (string, error) {
 	lookup := GetEnglishToBrailleLookup()
 	var result strings.Builder
 	for i := 0; i < len(input); i++ {
@@ -87,9 +87,9 @@ func EnglishToBrailleTranslator(input string) (string, error) {
 	return result.String(), nil
 }
 
-// BrailleToEnglishTranslator is a function that returns a converted English string from a Braille string
+// BrailleToEnglish is a function that returns a converted English string from a Braille string
 // As per Readme, only handles characters and numbers not including decimal and special symbols
-func BrailleToEnglishTranslator(input string) (string, error) {
+func BrailleToEnglish(input string) (string, error) {
 	characterLookup, digitLookup := GetBrailleToEnglishLookup()
 	var result strings.Builder
 	if len(input)%6 != 0 {

--- a/go/translator.go
+++ b/go/translator.go
@@ -27,14 +27,11 @@ func main() {
 	var err error
 	if isEnglish {
 		result, err = EnglishToBrailleTranslator(input)
-		if err != nil {
-			log.Fatal(err)
-		}
 	} else {
 		result, err = BrailleToEnglishTranslator(input)
-		if err != nil {
-			log.Fatal(err)
-		}
+	}
+	if err != nil {
+		log.Fatal(err)
 	}
 	fmt.Println(result)
 }

--- a/go/translator.go
+++ b/go/translator.go
@@ -51,6 +51,8 @@ func IsEnglish(input string) bool {
 	return false
 }
 
+// EnglishToBrailleTranslator is a function that returns a converted Braille string from an English string
+// As per Readme, only handles characters and numbers not including decimal and special symbols
 func EnglishToBrailleTranslator(input string) (string, error) {
 	lookup := GetEnglishToBrailleLookup()
 	var result strings.Builder
@@ -85,6 +87,8 @@ func EnglishToBrailleTranslator(input string) (string, error) {
 	return result.String(), nil
 }
 
+// BrailleToEnglishTranslator is a function that returns a converted English string from a Braille string
+// As per Readme, only handles characters and numbers not including decimal and special symbols
 func BrailleToEnglishTranslator(input string) (string, error) {
 	characterLookup, digitLookup := GetBrailleToEnglishLookup()
 	var result strings.Builder

--- a/go/translator.go
+++ b/go/translator.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"strings"
+	"unicode"
 )
 
 func main() {
@@ -14,6 +16,21 @@ func main() {
 	}
 	// Join with a space to preservce spaces in input.
 	input = strings.TrimSpace(strings.Join(os.Args[1:], " "))
+	isEnglish := IsEnglish(input)
+	var result string
+	var err error
+	if isEnglish {
+		result, err = EnglishToBrailleTranslator(input)
+		if err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		result, err = BrailleToEnglishTranslator(input) //todo: Implement
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+	fmt.Println(result)
 }
 
 // IsEnglish is a function that returns true if the input is english, and false if the input is braille.
@@ -29,4 +46,61 @@ func IsEnglish(input string) bool {
 		}
 	}
 	return false
+}
+
+func EnglishToBrailleTranslator(input string) (string, error) {
+	const (
+		CapitalFollows string = ".....O"
+		DecimalFollows string = ".O...O"
+		NumberFollows  string = ".O.OOO"
+	)
+	lookup := GetEnglishToBrailleLookup()
+	// inputRune = rune(input)
+	var result strings.Builder
+	for i := 0; i < len(input); i++ {
+		char := rune(input[i])
+		if unicode.IsDigit(char) {
+			var number strings.Builder
+			j := i
+			for j < len(input) && unicode.IsDigit(rune(input[j])) {
+				numberChar := rune(input[j])
+				if braille, ok := lookup[numberChar]; ok {
+					number.WriteString(braille)
+				} else {
+					log.Fatal("unable to convert from %v", numberChar)
+				}
+				j += 1
+			}
+			result.WriteString(NumberFollows)
+			result.WriteString(number.String())
+			i = j - 1
+		} else {
+			if unicode.IsUpper(char) {
+				result.WriteString(CapitalFollows)
+			}
+			if braille, ok := lookup[unicode.ToLower(char)]; ok {
+				result.WriteString(braille)
+			} else {
+				log.Fatal("unable to convert from %v", char)
+			}
+		}
+	}
+	return result.String(), nil
+}
+
+// GetEnglishToBrailleLookup returns the character lookup table for converting English into Braille.
+func GetEnglishToBrailleLookup() map[rune]string {
+	return map[rune]string{
+		// Lowercase letters and space
+		'a': "O.....", 'b': "O.O...", 'c': "OO....", 'd': "OO.O..", 'e': "O..O..",
+		'f': "OOO...", 'g': "OOOO..", 'h': "O.OO..", 'i': ".OO...", 'j': ".OOO..",
+		'k': "O...O.", 'l': "O.O.O.", 'm': "OO..O.", 'n': "OO.OO.", 'o': "O..OO.",
+		'p': "OOO.O.", 'q': "OOOOO.", 'r': "O.OOO.", 's': ".OO.O.", 't': ".OOOO.",
+		'u': "O...OO", 'v': "O.O.OO", 'w': ".OOO.O", 'x': "OO..OO", 'y': "OO.OOO",
+		'z': "O..OOO", ' ': "......",
+
+		// Numbers
+		'1': "O.....", '2': "O.O...", '3': "OO....", '4': "OO.O..", '5': "O..O..",
+		'6': "OOO...", '7': "OOOO..", '8': "O.OO..", '9': ".OO...", '0': ".OOO..",
+	}
 }

--- a/go/translator.go
+++ b/go/translator.go
@@ -13,5 +13,20 @@ func main() {
 		return
 	}
 	// Join with a space to preservce spaces in input.
-	input = strings.Join(os.Args[1:], " ")
+	input = strings.TrimSpace(strings.Join(os.Args[1:], " "))
+}
+
+// IsEnglish is a function that returns true if the input is english, and false if the input is braille.
+func IsEnglish(input string) bool {
+	const (
+		dotRune      = '.'
+		capitalORune = 'O'
+	)
+	for _, r := range input {
+		isBrailleRune := (r == dotRune || r == capitalORune)
+		if !isBrailleRune {
+			return true
+		}
+	}
+	return false
 }

--- a/go/translator.go
+++ b/go/translator.go
@@ -1,1 +1,17 @@
 package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	var input string
+	if len(os.Args) < 2 {
+		fmt.Println("Please provide a string to translate")
+		return
+	}
+	// Join with a space to preservce spaces in input.
+	input = strings.Join(os.Args[1:], " ")
+}


### PR DESCRIPTION
## Changes
This PR adds 2 new functions  `EnglishToBraille` and 'BrailleToEnglish' which translates an input string to their corresponding output string. Both functions use a similar approach of utilizing a map converting braille -> english and vice versa to translate the string. A benchmark is added measuring the performance for both way translations and can be ran with the following command:
```
go test -bench=. 
```

### Other implementations considered
This was initially implemented in a OO approach with a `Translator` interface and corresponding structs. 
While neater and more extensible, Go does not bundle dependencies in other files when running `go run translator.go test_case`, meaning the classes defined in other files would not be available during the test. To follow with the guideline of the challenge I condensed it into just functions. 

### Bugs and resolution
One bug encountered during development was duplicative mapping when translating from Braille to English. The initial solution attempted to reverse the English-to-Braille lookup map to reduce boilerplate. However, this led to ambiguity between numbers and characters. For example:
ex:

```
O..... -> a  
and 
O..... -> 1
``` 

To resolve this issue, the reversed map was printed out and separated into digits and characters.


### Challenge specific things
In case my email is not showing correctly: r29zhang@uwaterloo.ca
Thank you for your time!