### PR TITLE
Richard Kim - python solution

### DIFF
--- a/.github/workflows/python.self.yml
+++ b/.github/workflows/python.self.yml
@@ -2,6 +2,24 @@ name: self test
 
 on:
   workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+        type: choice
+        options:
+        - info
+        - warning
+        - debug
+      tags:
+        description: 'Test scenario tags'
+        required: false
+        type: boolean
+      environment:
+        description: 'Environment to run tests against'
+        type: environment
+        required: true
 
 jobs:
   python-tests:

--- a/.github/workflows/python.self.yml
+++ b/.github/workflows/python.self.yml
@@ -1,9 +1,7 @@
 name: self test
 
 on:
-  push:
-    branches:
-      - '**'  # just run on any branch, im only gonna be working from one anyway
+  workflow_dispatch:
 
 jobs:
   python-tests:

--- a/.github/workflows/python.self.yml
+++ b/.github/workflows/python.self.yml
@@ -1,0 +1,26 @@
+name: self test
+
+on:
+  push:
+    branches:
+      - '**'  # just run on any branch, im only gonna be working from one anyway
+
+jobs:
+  python-tests:
+    name: Run Python Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - id: changes
+        uses: jitterbit/get-changed-files@v1
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: Run Python Tests
+        run: |
+          cd python
+          python3 translator.self.test.py

--- a/.github/workflows/python.self.yml
+++ b/.github/workflows/python.self.yml
@@ -10,8 +10,10 @@ jobs:
     name: Run Python Tests
     runs-on: ubuntu-latest
     steps:
+      # you probably would want to use a higher version
       - uses: actions/checkout@v2
 
+      # uses set-output which is deprecated
       - id: changes
         uses: jitterbit/get-changed-files@v1
 

--- a/python/mappings.py
+++ b/python/mappings.py
@@ -67,5 +67,5 @@ puncuations = {
 
 # commands
 capital_follows = [6]
-decimal_follows = [2, 6]
+# decimal_follows = [2, 6]
 number_follows = [2, 4, 5, 6]

--- a/python/mappings.py
+++ b/python/mappings.py
@@ -7,6 +7,8 @@
 # 5 6
 # eg, a = [1]
 
+# using dictionaries for fast look ups for key -> value
+# not using additional dictionary for value -> key look up, just save on space and show both ways
 alphabets = {
     'a': [1],
     'b': [1, 3],

--- a/python/mappings.py
+++ b/python/mappings.py
@@ -8,7 +8,8 @@
 # eg, a = [1]
 
 # using dictionaries for fast look ups for key -> value
-# not using additional dictionary for value -> key look up, just save on space and show both ways
+# not using additional dictionary for value -> key look up, just save on space and show both ways of doing things
+# but i do understand it may be better to use the very little space and save on computation / time
 alphabets = {
     'a': [1],
     'b': [1, 3],

--- a/python/mappings.py
+++ b/python/mappings.py
@@ -1,0 +1,71 @@
+# instead of hard coding all alphabets using . and O, it will be easier to follow what it actually is. 
+# O indicates there is a bump, and . indicates its just flat.
+# so, build the alphabet mappings as an array of ints that show the position of the O, or where the bump will be in real life
+# positions:
+# 1 2
+# 3 4
+# 5 6
+# eg, a = [1]
+
+alphabets = {
+    'a': [1],
+    'b': [1, 3],
+    'c': [1, 2],
+    'd': [1, 2, 4],
+    'e': [1, 4],
+    'f': [1, 2, 3],
+    'g': [1, 2, 3, 4],
+    'h': [1, 3, 4],
+    'i': [2, 3],
+    'j': [2, 3, 4],
+    'k': [1, 5],
+    'l': [1, 3, 5],
+    'm': [1, 2, 5],
+    'n': [1, 2, 4, 5],
+    'o': [1, 4, 5],
+    'p': [1, 2, 3, 5],
+    'q': [1, 2, 3, 4, 5],
+    'r': [1, 3, 4, 5],
+    's': [2, 3, 5],
+    't': [2, 3, 4, 5],
+    'u': [1, 5, 6],
+    'v': [1, 3, 5, 6],
+    'w': [2, 3, 4, 6],
+    'x': [1, 2, 5, 6],
+    'y': [1, 2, 4, 5, 6],
+    'z': [1, 4, 5, 6]
+}
+
+numbers = {
+    '1': 'a',
+    '2': 'b',
+    '3': 'c',
+    '4': 'd',
+    '5': 'e',
+    '6': 'f',
+    '7': 'g',
+    '8': 'h',
+    '9': 'i',
+    '0': 'j'
+}
+
+puncuations = {
+    '.': [3, 4, 6],
+    ',': [3],
+    '?': [3, 5, 6],
+    '!': [3, 4, 5],
+    ':': [3, 4],
+    ';': [3, 5],
+    '-': [5, 6],
+    '/': [2, 5],
+    '<': [2, 3, 6],
+    '>': [1, 4, 5],
+    '(': [1, 3, 6],
+    ')': [2, 4, 5],
+    ' ': []
+}
+
+# commands
+capital_follows = [6]
+decimal_follows = [2, 6]
+number_follows = [2, 4, 5, 6]

--- a/python/translator.py
+++ b/python/translator.py
@@ -3,9 +3,11 @@ from mappings import alphabets, numbers, puncuations, capital_follows, decimal_f
 
 # Olocs = location of 'O's (bumps)
 def olocs_to_braille(olocs):
+    print(olocs)
     positions = ['.'] * 6
-    for loc in olocs:
-        positions[loc - 1] = 'O' # -1 to match indexes
+    if len(olocs) > 0:
+        for loc in olocs:
+            positions[loc - 1] = 'O' # -1 to match indexes
     return ''.join(positions)
 
 def braille_to_olocs(braille):
@@ -16,14 +18,15 @@ def english_to_braille(input_string):
     number_mode = False
     # loop and catch case by case
     for char in input_string:
+        print(f"char: {char}")
         if char == ' ':
-            output += puncuations[' ']
+            output += olocs_to_braille(puncuations[' '])
             number_mode = False
         elif char.isdigit():
             if not number_mode:
                 output += olocs_to_braille(number_follows)
                 number_mode = True
-            output += olocs_to_braille(numbers[char])
+            output += olocs_to_braille(alphabets[numbers[char]])
         else:
             if number_mode:
                 number_mode = False

--- a/python/translator.py
+++ b/python/translator.py
@@ -1,5 +1,5 @@
 import sys
-from mappings import alphabets, numbers, puncuations, capital_follows, decimal_follows, number_follows
+from mappings import alphabets, numbers, puncuations, capital_follows, number_follows
 
 # Olocs = location of 'O's (bumps)
 def olocs_to_braille(olocs):
@@ -25,9 +25,12 @@ def english_to_braille(input_string):
                 output += olocs_to_braille(number_follows)
                 number_mode = True
             output += olocs_to_braille(alphabets[numbers[char]])
+        # im aware punctuations are not necessary, but still for fun :)
+        elif char in {'.', ',', '?', '!', '(', ')', '-', '/', '<', '>'}: # use a set for that very minor time efficiency
+            number_mode = False # if it was true, it was still true by accident. turn it off
+            output += olocs_to_braille(puncuations[char])
         else:
-            if number_mode:
-                number_mode = False
+            number_mode = False # if it was true, it was still true by accident. turn it off
             if char.isupper():
                 output += olocs_to_braille(capital_follows)
                 char = char.lower()

--- a/python/translator.py
+++ b/python/translator.py
@@ -10,7 +10,11 @@ def olocs_to_braille(olocs):
     return ''.join(positions)
 
 def braille_to_olocs(braille):
-    return
+    positions = []
+    for i, char in enumerate(braille):
+        if char == 'O':
+            positions.append(i)
+    return positions
 
 def english_to_braille(input_string):
     output = ''
@@ -37,8 +41,48 @@ def english_to_braille(input_string):
             output += olocs_to_braille(alphabets[char])
     return output
 
+# just used to find char by olocs
+def find_keys_by_value(dict, value):
+    for key, val in dict.items():
+        if val == value:
+            return key
+    return None
+
 def braille_to_english(input_string):
-    return
+    output = ''
+    i = 0
+    input_length = len(input_string)
+    number_mode = False
+    capital_mode = False
+    while i < input_length:
+        if input_string[i] == ' ': # handling the weird case where braille would be inputed as two separate arguments
+            i += 1
+            continue
+        braille_char = input_string[i:i+6]
+        if len(braille_char) < 6: # shouldnt occur since its being caught at is_braille() but just in case
+            break
+        if braille_char == olocs_to_braille(puncuations[' ']):
+            output += ' '
+            number_mode = False
+        elif braille_char == olocs_to_braille(capital_follows):
+            capital_mode = True
+        elif braille_char == olocs_to_braille(number_follows):
+            number_mode = True
+        else:
+            if number_mode:
+                output += find_keys_by_value(numbers, find_keys_by_value(alphabets, braille_to_olocs(braille_char)))
+            else:
+                result_punct = find_keys_by_value(puncuations, braille_to_olocs(braille_char))
+                if result_punct: # there arent any empty strings or False or 0, so its okay to just use if result
+                    output += result_punct
+                else:
+                    result_alphabet = find_keys_by_value(alphabets, braille_to_olocs(braille_char))
+                    if capital_mode:
+                        result_alphabet = result_alphabet.upper()
+                        capital_mode = False
+                    output += result_alphabet
+        i += 6
+    return output
 
 def is_braille(input_string):
     input_string_no_spaces = input_string.replace(' ', '')
@@ -62,5 +106,5 @@ def main():
         output = english_to_braille(input_string)
     print(output)
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/python/translator.py
+++ b/python/translator.py
@@ -3,7 +3,6 @@ from mappings import alphabets, numbers, puncuations, capital_follows, decimal_f
 
 # Olocs = location of 'O's (bumps)
 def olocs_to_braille(olocs):
-    print(olocs)
     positions = ['.'] * 6
     if len(olocs) > 0:
         for loc in olocs:
@@ -18,7 +17,6 @@ def english_to_braille(input_string):
     number_mode = False
     # loop and catch case by case
     for char in input_string:
-        print(f"char: {char}")
         if char == ' ':
             output += olocs_to_braille(puncuations[' '])
             number_mode = False

--- a/python/translator.py
+++ b/python/translator.py
@@ -6,14 +6,14 @@ def olocs_to_braille(olocs):
     positions = ['.'] * 6
     if len(olocs) > 0:
         for loc in olocs:
-            positions[loc - 1] = 'O' # -1 to match indexes
+            positions[loc - 1] = 'O' # -1 to match index
     return ''.join(positions)
 
 def braille_to_olocs(braille):
     positions = []
     for i, char in enumerate(braille):
         if char == 'O':
-            positions.append(i)
+            positions.append(i + 1) # + 1 to add index
     return positions
 
 def english_to_braille(input_string):
@@ -54,6 +54,7 @@ def braille_to_english(input_string):
     input_length = len(input_string)
     number_mode = False
     capital_mode = False
+    prev_tri_bracket = False
     while i < input_length:
         if input_string[i] == ' ': # handling the weird case where braille would be inputed as two separate arguments
             i += 1
@@ -73,7 +74,14 @@ def braille_to_english(input_string):
                 output += find_keys_by_value(numbers, find_keys_by_value(alphabets, braille_to_olocs(braille_char)))
             else:
                 result_punct = find_keys_by_value(puncuations, braille_to_olocs(braille_char))
-                if result_punct: # there arent any empty strings or False or 0, so its okay to just use if result
+                # there arent any empty strings or False or 0, so its okay to just use if result_punct
+                # assume the closing triangular bracket '>' will only come after a opening one '<'
+                # if the bracket was not opened previously, consider it the alphabet 'o'
+                if (result_punct and result_punct != '>') or (result_punct and result_punct == '>' and prev_tri_bracket):
+                    if (result_punct == '<'):
+                        prev_tri_bracket = True
+                    if (result_punct == '>'):
+                        prev_tri_bracket = False
                     output += result_punct
                 else:
                     result_alphabet = find_keys_by_value(alphabets, braille_to_olocs(braille_char))

--- a/python/translator.py
+++ b/python/translator.py
@@ -1,1 +1,62 @@
+import sys
+from mappings import alphabets, numbers, puncuations, capital_follows, decimal_follows, number_follows
 
+# Olocs = location of 'O's (bumps)
+def olocs_to_braille(olocs):
+    positions = ['.'] * 6
+    for loc in olocs:
+        positions[loc - 1] = 'O' # -1 to match indexes
+    return ''.join(positions)
+
+def braille_to_olocs(braille):
+    return
+
+def english_to_braille(input_string):
+    output = ''
+    number_mode = False
+    # loop and catch case by case
+    for char in input_string:
+        if char == ' ':
+            output += puncuations[' ']
+            number_mode = False
+        elif char.isdigit():
+            if not number_mode:
+                output += olocs_to_braille(number_follows)
+                number_mode = True
+            output += olocs_to_braille(numbers[char])
+        else:
+            if number_mode:
+                number_mode = False
+            if char.isupper():
+                output += olocs_to_braille(capital_follows)
+                char = char.lower()
+            output += olocs_to_braille(alphabets[char])
+    return output
+
+def braille_to_english(input_string):
+    return
+
+def is_braille(input_string):
+    input_string_no_spaces = input_string.replace(' ', '')
+    # braille should only be in O and .
+    for char in input_string_no_spaces:
+        if char not in ('O', '.'):
+            return False
+    # it also should be in multiple of 6s
+    if len(input_string_no_spaces) % 6 != 0:
+        return False
+    return True
+
+def main():
+    args = sys.argv[1:]
+    if not args: # not accepting false runs
+        return
+    input_string = ' '.join(args)
+    if is_braille(input_string):
+        output = braille_to_english(input_string)
+    else:
+        output = english_to_braille(input_string)
+    print(output)
+
+if __name__ == "__main__":
+    main()

--- a/python/translator.py
+++ b/python/translator.py
@@ -26,7 +26,7 @@ def english_to_braille(input_string):
                 number_mode = True
             output += olocs_to_braille(alphabets[numbers[char]])
         # im aware punctuations are not necessary, but still for fun :)
-        elif char in {'.', ',', '?', '!', '(', ')', '-', '/', '<', '>'}: # use a set for that very minor time efficiency
+        elif char in {'.', ',', '?', '!', ':', ';', '(', ')', '-', '/', '<', '>'}: # use a set for that very minor time efficiency
             number_mode = False # if it was true, it was still true by accident. turn it off
             output += olocs_to_braille(puncuations[char])
         else:

--- a/python/translator.self.test.py
+++ b/python/translator.self.test.py
@@ -1,0 +1,21 @@
+import unittest
+import subprocess
+
+# just a little file so i can run some individual tests on my own workflow
+
+class TestTranslator(unittest.TestCase):
+    def test_output(self):
+        # Command to run translator.py script
+        command = ["python3", "translator.py", "Abc", "123", "xYz"]
+        
+        # Run the command and capture output
+        result = subprocess.run(command, capture_output=True, text=True)
+        
+        # Expected output without the newline at the end
+        expected_output = ".....OO.....O.O...OO...........O.OOOO.....O.O...OO..........OO..OO.....OOO.OOOO..OOO"
+        
+        # Strip any leading/trailing whitespace from the output and compare
+        self.assertEqual(result.stdout.strip(), expected_output)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/translator.self.test.py
+++ b/python/translator.self.test.py
@@ -6,13 +6,13 @@ import subprocess
 class TestTranslator(unittest.TestCase):
     def test_output(self):
         # Command to run translator.py script
-        command = ["python3", "translator.py", "Abc", "123", "xYz"]
+        command = ["python3", "translator.py", "Abc", "123", "xYz", "Hello", "world1", "42"]
         
         # Run the command and capture output
         result = subprocess.run(command, capture_output=True, text=True)
         
         # Expected output without the newline at the end
-        expected_output = ".....OO.....O.O...OO...........O.OOOO.....O.O...OO..........OO..OO.....OOO.OOOO..OOO"
+        expected_output = ".....OO.....O.O...OO...........O.OOOO.....O.O...OO..........OO..OO.....OOO.OOOO..OOO...........OO.OO..O..O..O.O.O.O.O.O.O..OO........OOO.OO..OO.O.OOO.O.O.O.OO.O...O.OOOO............O.OOOOO.O..O.O..."
         
         # Strip any leading/trailing whitespace from the output and compare
         self.assertEqual(result.stdout.strip(), expected_output)

--- a/python/translator.self.test.py
+++ b/python/translator.self.test.py
@@ -30,6 +30,64 @@ class TestTranslator(unittest.TestCase):
         
         # Strip any leading/trailing whitespace from the output and compare
         self.assertEqual(result.stdout.strip(), expected_output)
+    
+    # > and o are same in braille, made the assumption > will only come after an opening
+    def test_braille_to_english_edge_case_tribracket(self):
+        # Command to run translator.py script
+        braille_input = ".OO..OO..OO.O..OO."
+        command = ["python3", "translator.py", braille_input]
+        
+        # Run the command and capture output
+        result = subprocess.run(command, capture_output=True, text=True)
+        
+        # Expected output without the newline at the end
+        expected_output = "<>o"
+        
+        # Strip any leading/trailing whitespace from the output and compare
+        self.assertEqual(result.stdout.strip(), expected_output)
+    
+    # case where braille input are given in multple arguments
+    def test_braille_to_english_edge_case_diff_args(self):
+        # Command to run translator.py script
+        command = ["python3", "translator.py", ".....OO.OO..O..O..O.O.O.O.O.O.O..OO.", ".OOO.OO..OO.O.OOO.O.O.O.OO.O.."]
+        
+        # Run the command and capture output
+        result = subprocess.run(command, capture_output=True, text=True)
+        
+        # Expected output without the newline at the end
+        expected_output = "Helloworld"
+        
+        # Strip any leading/trailing whitespace from the output and compare
+        self.assertEqual(result.stdout.strip(), expected_output)
+    
+    # mostly braille but includes other char than . and O
+    # just becomes a code
+    def test_braille_to_english_edge_case_diff_args(self):
+        # Command to run translator.py script
+        command = ["python3", "translator.py", ".....OO.OO..O..O..O.O.O.O.O.O.O..OO.a"]
+        
+        # Run the command and capture output
+        result = subprocess.run(command, capture_output=True, text=True)
+        
+        # Expected output without the newline at the end
+        expected_output = "..OO.O..OO.O..OO.O..OO.O..OO.O.....OO..OO......OO..OO...OO.O.....OO..OO......OO..OO...OO.O..OO.O.....OO..OO...OO.O..OO.O.....OO..OO...OO.O..OO.O.....OO..OO...OO.O.....OO..OO...OO.O.....OO..OO...OO.O.....OO..OO...OO.O.....OO..OO...OO.O.....OO..OO...OO.O.....OO..OO...OO.O..OO.O.....OO..OO......OO..OO...OO.OO....."
+        
+        # Strip any leading/trailing whitespace from the output and compare
+        self.assertEqual(result.stdout.strip(), expected_output)
+    
+    # mostly braille but missing a dot, resulting in %6 != 0
+    def test_braille_to_english_edge_case_diff_args(self):
+        # Command to run translator.py script
+        command = ["python3", "translator.py", ".OOO.OO..OO.O.OOO.O.O.O.OO.O."]
+        
+        # Run the command and capture output
+        result = subprocess.run(command, capture_output=True, text=True)
+        
+        # Expected output without the newline at the end
+        expected_output = "..OO.O.....OO..OO......OO..OO......OO..OO...OO.O.....OO..OO......OO..OO...OO.O..OO.O.....OO..OO......OO..OO...OO.O.....OO..OO...OO.O.....OO..OO......OO..OO......OO..OO...OO.O.....OO..OO...OO.O.....OO..OO...OO.O.....OO..OO...OO.O.....OO..OO......OO..OO...OO.O.....OO..OO...OO.O"
+        
+        # Strip any leading/trailing whitespace from the output and compare
+        self.assertEqual(result.stdout.strip(), expected_output)
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/translator.self.test.py
+++ b/python/translator.self.test.py
@@ -4,7 +4,7 @@ import subprocess
 # just a little file so i can run some individual tests on my own workflow
 
 class TestTranslator(unittest.TestCase):
-    def test_output(self):
+    def test_english_to_braille(self):
         # Command to run translator.py script
         command = ["python3", "translator.py", "Abc", "123", "xYz", "Hello", "world1", "42", ":)"]
         
@@ -13,6 +13,20 @@ class TestTranslator(unittest.TestCase):
         
         # Expected output without the newline at the end
         expected_output = ".....OO.....O.O...OO...........O.OOOO.....O.O...OO..........OO..OO.....OOO.OOOO..OOO...........OO.OO..O..O..O.O.O.O.O.O.O..OO........OOO.OO..OO.O.OOO.O.O.O.OO.O...O.OOOO............O.OOOOO.O..O.O...........OO...O.OO."
+        
+        # Strip any leading/trailing whitespace from the output and compare
+        self.assertEqual(result.stdout.strip(), expected_output)
+    
+    def test_braille_to_english(self):
+        # Command to run translator.py script
+        braille_input = ".....OO.....O.O...OO...........O.OOOO.....O.O...OO..........OO..OO.....OOO.OOOO..OOO...........OO.OO..O..O..O.O.O.O.O.O.O..OO........OOO.OO..OO.O.OOO.O.O.O.OO.O...O.OOOO............O.OOOOO.O..O.O...........OO...O.OO."
+        command = ["python3", "translator.py", braille_input]
+        
+        # Run the command and capture output
+        result = subprocess.run(command, capture_output=True, text=True)
+        
+        # Expected output without the newline at the end
+        expected_output = "Abc 123 xYz Hello world1 42 :)"
         
         # Strip any leading/trailing whitespace from the output and compare
         self.assertEqual(result.stdout.strip(), expected_output)

--- a/python/translator.self.test.py
+++ b/python/translator.self.test.py
@@ -6,13 +6,13 @@ import subprocess
 class TestTranslator(unittest.TestCase):
     def test_output(self):
         # Command to run translator.py script
-        command = ["python3", "translator.py", "Abc", "123", "xYz", "Hello", "world1", "42"]
+        command = ["python3", "translator.py", "Abc", "123", "xYz", "Hello", "world1", "42", ":)"]
         
         # Run the command and capture output
         result = subprocess.run(command, capture_output=True, text=True)
         
         # Expected output without the newline at the end
-        expected_output = ".....OO.....O.O...OO...........O.OOOO.....O.O...OO..........OO..OO.....OOO.OOOO..OOO...........OO.OO..O..O..O.O.O.O.O.O.O..OO........OOO.OO..OO.O.OOO.O.O.O.OO.O...O.OOOO............O.OOOOO.O..O.O..."
+        expected_output = ".....OO.....O.O...OO...........O.OOOO.....O.O...OO..........OO..OO.....OOO.OOOO..OOO...........OO.OO..O..O..O.O.O.O.O.O.O..OO........OOO.OO..OO.O.OOO.O.O.O.OO.O...O.OOOO............O.OOOOO.O..O.O...........OO...O.OO."
         
         # Strip any leading/trailing whitespace from the output and compare
         self.assertEqual(result.stdout.strip(), expected_output)


### PR DESCRIPTION
Notes:
- created test cases in translator.self.test.py and ran it on new workflow - python.self.yml
- included support for punctuations for fun
- may include bugs if inputs include typos. cases are not handled gracefully using sys.exit(1) + err msg since instructions mentioned no other message should be outputted

Assumptions:
- no major typo in braille eg) non-number coming after number_follows, etc
- if any other character is inputted other than '.' or 'O', it is treated as English
- if total len of braille % 6 != 0, it is treated as English
- when using '<', '>', assume the closing triangular bracket '>' will only come after a opening one '<'. if the bracket was not opened previously, consider it the alphabet 'o'

Future To-Do if continued:
- Would be interesting to detect possible typos in braille and suggest auto-correction
