### PR TITLE
Braille Translator Solution

### DIFF
--- a/javascript/isBraille/__tests__/toBraile.test.js
+++ b/javascript/isBraille/__tests__/toBraile.test.js
@@ -1,0 +1,36 @@
+const isBraille = require('../index');
+
+describe('isBraille function', () => {
+  test('returns true for a valid Braille string', () => {
+    expect(isBraille('O.O.OO')).toBe(true);
+    expect(isBraille('O.O.OO.O.O.O')).toBe(true);
+    expect(isBraille('O.OO..')).toBe(true);
+  })
+
+  test('returns false for a string not divisible by 6', () => {
+    expect(isBraille('O.O')).toBe(false);
+    expect(isBraille('O.O.O')).toBe(false);
+    expect(isBraille('O.O.OOO')).toBe(false);
+  })
+
+  test('returns false for a string containing invalid characters', () => {
+    expect(isBraille('O.O.XO')).toBe(false);
+    expect(isBraille('O.OO,')).toBe(false);
+    expect(isBraille('')).toBe(false);
+  })
+
+  test('returns false for an empty string', () => {
+    expect(isBraille('')).toBe(false);
+  })
+
+  test('returns false for strings with characters other than "." and "O"', () => {
+    expect(isBraille('O.OO!O')).toBe(false);
+    expect(isBraille('OO.O0.')).toBe(false);
+    expect(isBraille('O..O$O')).toBe(false);
+  })
+
+  test('handles edge cases correctly', () => {
+    expect(isBraille('.O.O.O')).toBe(true);
+    expect(isBraille('OO....')).toBe(true);
+  })
+})

--- a/javascript/isBraille/index.js
+++ b/javascript/isBraille/index.js
@@ -1,0 +1,6 @@
+
+const isBraille = string => {
+
+}
+
+module.exports = isBraille;

--- a/javascript/isBraille/index.js
+++ b/javascript/isBraille/index.js
@@ -1,6 +1,13 @@
 
+// Function that checks if a string passed, is a braille string or a regular one.
 const isBraille = string => {
+  // if string is not divisble by 6, then it cannot be a true brailie string.
+  if (string.length % 6 > 0) return false;
+  
+  // if string does not contain combinations of . symbol and O symbol, then its not a brailie.
+  if (!(/^[.O]+$/.test(string))) return false;
 
+  return true;
 }
 
 module.exports = isBraille;

--- a/javascript/toBraille/__tests__/toBraille.test.js
+++ b/javascript/toBraille/__tests__/toBraille.test.js
@@ -17,6 +17,7 @@ describe('toBraille function', () => {
   test('returns true for valid braille numbers', () => {
     expect(toBraille('1')).toBe('.O.OOOO.....'); 
     expect(toBraille('123')).toBe('.O.OOOO.....O.O...OO....');
+    expect(toBraille('12.32')).toBe('.O.OOOO.....O.O.....OO.OOO....O.O...');
     expect(toBraille('123 ')).toBe('.O.OOOO.....O.O...OO..........');
   })
 

--- a/javascript/toBraille/__tests__/toBraille.test.js
+++ b/javascript/toBraille/__tests__/toBraille.test.js
@@ -1,0 +1,26 @@
+const toBraille = require('../index');
+
+describe('toBraille function', () => {
+  test('returns true for a valid Braille string', () => {
+    expect(toBraille('a')).toBe('O.....'); 
+    expect(toBraille('dog')).toBe('OO.O..O..OO.OOOO..'); 
+    expect(toBraille('world')).toBe('.OOO.OO..OO.O.OOO.O.O.O.OO.O..'); 
+  });
+
+  test('returns true for valid Braille string with capital letters', () => {
+    expect(toBraille('A')).toBe('.....OO.....'); 
+    expect(toBraille('Dog')).toBe('.....OOO.O..O..OO.OOOO..');
+    expect(toBraille('Dog Dog')).toBe('.....OOO.O..O..OO.OOOO.............OOO.O..O..OO.OOOO..');
+    expect(toBraille('World')).toBe('.....O.OOO.OO..OO.O.OOO.O.O.O.OO.O..');
+  })
+
+  test('returns true for valid braille numbers', () => {
+    expect(toBraille('1')).toBe('.O.OOOO.....'); 
+    expect(toBraille('123')).toBe('.O.OOOO.....O.O...OO....');
+    expect(toBraille('123 ')).toBe('.O.OOOO.....O.O...OO..........');
+  })
+
+  test('translator.test.js test', () => {
+    expect(toBraille('Abc 123 xYz')).toBe('.....OO.....O.O...OO...........O.OOOO.....O.O...OO..........OO..OO.....OOO.OOOO..OOO');
+  })
+});

--- a/javascript/toBraille/brailleMapping.js
+++ b/javascript/toBraille/brailleMapping.js
@@ -1,0 +1,66 @@
+
+const alphabet = {
+  a: 'O.....',
+  b: 'O.O...',
+  c: 'OO....',
+  d: 'OO.O..',
+  e: 'O..O..',
+  f: 'OOO...',
+  g: 'OOOO..',
+  h: 'O.OO..',
+  i: '.OO...',
+  j: '.OOO..',
+  k: 'O...O.',
+  l: 'O.O.O.',
+  m: 'OO..O.',
+  n: 'OO.OO.',
+  o: 'O..OO.',
+  p: 'OOO.O.',
+  q: 'OOOOO.',
+  r: 'O.OOO.',
+  s: '.OO.O.',
+  t: '.OOOO.',
+  u: 'O...OO',
+  v: 'O.O.OO',
+  w: '.OOO.O',
+  x: 'OO..OO',
+  y: 'OO.OOO',
+  z: 'O..OOO',
+}
+
+const numbers = {
+  '1': 'O.....',
+  '2': 'O.O...',
+  '3': 'OO....',
+  '4': 'OO.O..',
+  '5': 'O..O..',
+  '6': 'OOO...',
+  '7': 'OOOO..',
+  '8': 'O.OO..',
+  '9': '.OO...',
+  '0': '.OOO..',
+}
+
+const symbols = {
+  '.': '..OO.O',
+  ',': '..O...',
+  '?': '..O.OO',
+  '!': '..OOO.',
+  ':': '..OO..',
+  ';': '..O.O.',
+  '-': '....OO',
+  '/': '.O..O.',
+  '<': '.OO..O',
+  '>': 'O..OO.',
+  '(': 'O.O..O',
+  ')': '.O.OO.',
+  ' ': '......'
+}
+
+const follows = {
+  CAP:  '.....O',
+  DEC:  '.O...O',
+  NUM:   '.O.OOO',
+}
+
+module.exports = {alphabet, numbers, symbols, follows};

--- a/javascript/toBraille/index.js
+++ b/javascript/toBraille/index.js
@@ -4,7 +4,6 @@ const {alphabet, numbers, symbols, follows} = require('./brailleMapping');
 // symbols for accessing "follows"
 const CAPITAL = 'CAP';
 const NUMBER = 'NUM';
-const DECIMAL = 'DEC';
 
 const toBraille = string => {
   let result = '';
@@ -12,7 +11,7 @@ const toBraille = string => {
 
   for (let letter of string) {
 
-    if (numberConvertStarted && (!letter.match(/[0-9]/))) {
+    if (numberConvertStarted && (!letter.match(/[.0-9]/))) {
       numberConvertStarted = false;
     }
 

--- a/javascript/toBraille/index.js
+++ b/javascript/toBraille/index.js
@@ -1,6 +1,45 @@
 
-const toBraille = string => {
+const {alphabet, numbers, symbols, follows} = require('./brailleMapping');
 
+// symbols for accessing "follows"
+const CAPITAL = 'CAP';
+const NUMBER = 'NUM';
+const DECIMAL = 'DEC';
+
+const toBraille = string => {
+  let result = '';
+  let numberConvertStarted = false;
+
+  for (let letter of string) {
+
+    if (numberConvertStarted && (!letter.match(/[0-9]/))) {
+      numberConvertStarted = false;
+    }
+
+    if (letter.match(/[a-z]/)) {   // match lowercase letter
+
+      result += alphabet[letter];
+      
+    } else if (letter.match(/[A-Z]/)) { // match uppercase letter and add "CAPITAL FOLLOWS"
+
+      result += `${follows[CAPITAL]}${alphabet[letter.toLowerCase()]}`;
+
+    } else if (letter.match(/[.,?!:;\-\/<>\(\)\s]/)) {
+
+      result += symbols[letter];
+
+    } else if (letter.match(/[0-9]/)) { // match digit
+
+      if (!numberConvertStarted) {
+        numberConvertStarted = true;
+        result += `${follows[NUMBER]}`
+      }
+      result += numbers[letter];
+
+    }
+  }
+
+  return result;
 }
 
 module.exports = toBraille;

--- a/javascript/toBraille/index.js
+++ b/javascript/toBraille/index.js
@@ -1,0 +1,6 @@
+
+const toBraille = string => {
+
+}
+
+module.exports = toBraille;

--- a/javascript/toEnglish/__tests__/toEnglish.test.js
+++ b/javascript/toEnglish/__tests__/toEnglish.test.js
@@ -18,6 +18,7 @@ describe('toEnglish function', () => {
   test('returns true for valid braille numbers', () => {
     expect(toEnglish('.O.OOOO.....')).toBe('1'); 
     expect(toEnglish('.O.OOOO.....O.O...OO....')).toBe('123');
+    expect(toEnglish('.O.OOOO.....O.O.....OO.OOO....')).toBe('12.3');
     expect(toEnglish('.O.OOOO.....O.O...OO..........')).toBe('123 ');
   })
 

--- a/javascript/toEnglish/__tests__/toEnglish.test.js
+++ b/javascript/toEnglish/__tests__/toEnglish.test.js
@@ -1,0 +1,27 @@
+
+const toEnglish = require('../index');
+
+describe('toEnglish function', () => {
+  test('tests for english to braile easy words', () => {
+    expect(toEnglish('O.....')).toBe('a'); 
+    expect(toEnglish('OO.O..O..OO.OOOO..')).toBe('dog'); 
+    expect(toEnglish('.OOO.OO..OO.O.OOO.O.O.O.OO.O..')).toBe('world'); 
+  });
+
+  test('returns true for valid Braille string with capital letters', () => {
+    expect(toEnglish('.....OO.....')).toBe('A'); 
+    expect(toEnglish('.....OOO.O..O..OO.OOOO..')).toBe('Dog');
+    expect(toEnglish('.....OOO.O..O..OO.OOOO.............OOO.O..O..OO.OOOO..')).toBe('Dog Dog');
+    expect(toEnglish('.....O.OOO.OO..OO.O.OOO.O.O.O.OO.O..')).toBe('World');
+  })
+
+  test('returns true for valid braille numbers', () => {
+    expect(toEnglish('.O.OOOO.....')).toBe('1'); 
+    expect(toEnglish('.O.OOOO.....O.O...OO....')).toBe('123');
+    expect(toEnglish('.O.OOOO.....O.O...OO..........')).toBe('123 ');
+  })
+
+  test('translator.test.js test', () => {
+    expect(toEnglish('.....OO.....O.O...OO...........O.OOOO.....O.O...OO..........OO..OO.....OOO.OOOO..OOO')).toBe('Abc 123 xYz');
+  })
+});

--- a/javascript/toEnglish/alphabetMapping.js
+++ b/javascript/toEnglish/alphabetMapping.js
@@ -1,0 +1,66 @@
+
+const alphabet = {
+  'O.....': 'a',
+  'O.O...': 'b',
+  'OO....': 'c',
+  'OO.O..': 'd',
+  'O..O..': 'e',
+  'OOO...': 'f',
+  'OOOO..': 'g',
+  'O.OO..': 'h',
+  '.OO...': 'i',
+  '.OOO..': 'j',
+  'O...O.': 'k',
+  'O.O.O.': 'l',
+  'OO..O.': 'm',
+  'OO.OO.': 'n',
+  'O..OO.': 'o',
+  'OOO.O.': 'p',
+  'OOOOO.': 'q',
+  'O.OOO.': 'r',
+  '.OO.O.': 's',
+  '.OOOO.': 't',
+  'O...OO': 'u',
+  'O.O.OO': 'v',
+  '.OOO.O': 'w',
+  'OO..OO': 'x',
+  'OO.OOO': 'y',
+  'O..OOO': 'z',
+}
+
+const numbers = {
+  'O.....': '1',
+  'O.O...': '2',
+  'OO....': '3',
+  'OO.O..': '4',
+  'O..O..': '5',
+  'OOO...': '6',
+  'OOOO..': '7',
+  'O.OO..': '8',
+  '.OO...': '9',
+  '.OOO..': '0',
+}
+
+const symbols = {
+  '..OO.O': '.',
+  '..O...': ',',
+  '..O.OO': '?',
+  '..OOO.': '!',
+  '..OO..': ':',
+  '..O.O.': ';',
+  '....OO': '-',
+  '.O..O.': '/',
+  '.OO..O': '<',
+  'O..OO.': '>',
+  'O.O..O': '(',
+  '.O.OO.': ')',
+  '......': ' ',
+}
+
+const follows = {
+  '.....O': 'CAP',
+  '.O...O': 'DEC',
+  '.O.OOO': 'NUM',
+}
+
+module.exports = {alphabet, numbers, symbols, follows};

--- a/javascript/toEnglish/index.js
+++ b/javascript/toEnglish/index.js
@@ -8,6 +8,52 @@ const DECIMAL = 'DEC';
 
 
 const toEnglish = string => {
+  let result = '';
+  let numberConvertStarted = false;
+  let isCapital = false;
+  let isNumber = false;
+
+  // parses a braille string into an array of strings that are 6 characters long
+  const brailleArrayString = string.match(/.{1,6}/g);
+
+  for (let brailleSymbol of brailleArrayString) {
+    //if number was enabled but nothing matches numbers, then turn of number converter
+    if (isNumber && !numbers[brailleSymbol]) {
+      isNumber = false;
+    }
+    // preconditions
+    if (follows[brailleSymbol]) {
+      // if seen a capital symbol, set flag, go to the next character
+      if (follows[brailleSymbol] === CAPITAL) {
+        isCapital = true;
+        continue;
+      }
+
+      // seen a number symbol, set flag and go to the next character
+      if (follows[brailleSymbol] === NUMBER) {
+        isNumber = true;
+        continue;
+      }
+    }
+
+    // alphabet and symbols conditions
+    if (alphabet[brailleSymbol] && !isNumber) {
+      result += isCapital ? alphabet[brailleSymbol].toUpperCase() : alphabet[brailleSymbol];
+      // reset capital letter flag if it was set before
+      if (isCapital) {
+        isCapital = false;
+      }
+    } else if (symbols[brailleSymbol]) {
+      result += symbols[brailleSymbol];
+    }
+
+    // number conditions
+    if (isNumber && numbers[brailleSymbol]) {
+      result += numbers[brailleSymbol];
+    }
+  }
+
+  return result;
 
 }
 

--- a/javascript/toEnglish/index.js
+++ b/javascript/toEnglish/index.js
@@ -9,7 +9,6 @@ const DECIMAL = 'DEC';
 
 const toEnglish = string => {
   let result = '';
-  let numberConvertStarted = false;
   let isCapital = false;
   let isNumber = false;
 

--- a/javascript/toEnglish/index.js
+++ b/javascript/toEnglish/index.js
@@ -4,7 +4,6 @@ const {alphabet, numbers, symbols, follows} = require('./alphabetMapping');
 // symbols for accessing "follows"
 const CAPITAL = 'CAP';
 const NUMBER = 'NUM';
-const DECIMAL = 'DEC';
 
 
 const toEnglish = string => {
@@ -16,8 +15,9 @@ const toEnglish = string => {
   const brailleArrayString = string.match(/.{1,6}/g);
 
   for (let brailleSymbol of brailleArrayString) {
-    //if number was enabled but nothing matches numbers, then turn of number converter
-    if (isNumber && !numbers[brailleSymbol]) {
+
+    //if number was enabled but nothing matches numbers, and not a dot, then turn of number converter
+    if (isNumber && !numbers[brailleSymbol] && symbols[brailleSymbol] !== '.') {
       isNumber = false;
     }
     // preconditions

--- a/javascript/toEnglish/index.js
+++ b/javascript/toEnglish/index.js
@@ -1,0 +1,14 @@
+
+const {alphabet, numbers, symbols, follows} = require('./alphabetMapping');
+
+// symbols for accessing "follows"
+const CAPITAL = 'CAP';
+const NUMBER = 'NUM';
+const DECIMAL = 'DEC';
+
+
+const toEnglish = string => {
+
+}
+
+module.exports = toEnglish;

--- a/javascript/translator.js
+++ b/javascript/translator.js
@@ -1,0 +1,12 @@
+
+const isBraille = require("./isBraille");
+const toBraille = require("./toBraille");
+const toEnglish = require("./toEnglish");
+
+const string = process.argv.slice(2).join(' ');
+
+if (isBraille(string)) {
+  console.log(toEnglish(string));
+} else {
+  console.log(toBraille(string));
+}


### PR DESCRIPTION
Solution to translate Braille to English and English to Braille. 

Note: `Decimal Follows` was never used and never shown an example of (nor found an example online on braille sites). 