### PR TITLE
Python Solution: Mark Mekhail

### DIFF
--- a/python/constants.py
+++ b/python/constants.py
@@ -1,4 +1,4 @@
-from typing import Dict, Frozenset
+from typing import Dict, FrozenSet
 
 # Language constants
 ENGLISH : str = "english"
@@ -15,9 +15,9 @@ INVALID_INPUT_MSG    : str = "Invalid input.\nOnly alphanumeric characters and s
 INVALID_CHAR_SEQ_MSG : str = "Invalid character sequence.\nNumerical characters must be followed by a space or another numerical character.\nCapital characters must be followed by an alphabetical character.\nBraille sequences cannot end with a capital or number modifier."
 
 # Character sets
-PERMITTED_NON_ALPHANUMERIC_CHARS : Frozenset[str] = frozenset([" "])
-PERMITTED_MODIFIERS              : Frozenset[str] = frozenset([CAPITAL, NUMBER])
-NUMBER_TERMINATING_CHARS         : Frozenset[str] = frozenset([" "])
+PERMITTED_NON_ALPHANUMERIC_CHARS : FrozenSet[str] = frozenset([" "])
+PERMITTED_MODIFIERS              : FrozenSet[str] = frozenset([CAPITAL, NUMBER])
+NUMBER_TERMINATING_CHARS         : FrozenSet[str] = frozenset([" "])
 
 # Translation dictionaries
 ENGLISH_TO_BRAILLE : Dict[str, str] = {

--- a/python/constants.py
+++ b/python/constants.py
@@ -7,8 +7,8 @@ CAPITAL : str = "capital"
 NUMBER  : str = "number"
 
 # Braille language constants
-BRAILLE_CAPITAL_MODIFIER : str = ".....O"
-BRAILLE_NUMBER_MODIFIER  : str = ".O.OOO"
+CAPITAL_FOLLOWS : str = ".....O"
+NUMBER_FOLLOWS  : str = ".O.OOO"
 
 # Error messages
 INVALID_INPUT_MSG    : str = "Invalid input.\nOnly alphanumeric characters and spaces are allowed for english.\nOnly supported sequences of '.' and 'O' are allowed for braille. Refer to the project README for a description of supported braille characters."
@@ -21,49 +21,23 @@ NUMBER_TERMINATING_CHARS         : FrozenSet[str] = frozenset([" "])
 
 # Translation dictionaries
 ENGLISH_TO_BRAILLE : Dict[str, str] = {
-    " "     : "......",
-    "a"     : "O.....",
-    "b"     : "O.O...",
-    "c"     : "OO....",
-    "d"     : "OO.O..",
-    "e"     : "O..O..",
-    "f"     : "OOO...",
-    "g"     : "OOOO..",
-    "h"     : "O.OO..",
-    "i"     : ".OO...",
-    "j"     : ".OOO..",
-    "k"     : "O...O.",
-    "l"     : "O.O.O.",
-    "m"     : "OO..O.",
-    "n"     : "OO.OO.",
-    "o"     : "O..OO.",
-    "p"     : "OOO.O.",
-    "q"     : "OOOOO.",
-    "r"     : "O.OOO.",
-    "s"     : ".OO.O.",
-    "t"     : ".OOOO.",
-    "u"     : "O...OO",
-    "v"     : "O.O.OO",
-    "w"     : ".OOO.O",
-    "x"     : "OO..OO",
-    "y"     : "OO.OOO",
-    "z"     : "O..OOO",
-    CAPITAL : BRAILLE_CAPITAL_MODIFIER,
-    NUMBER  : BRAILLE_NUMBER_MODIFIER
+    " " : "......", "a" : "O.....", "b" : "O.O...", 
+    "c" : "OO....", "d" : "OO.O..", "e" : "O..O..",
+    "f" : "OOO...", "g" : "OOOO..", "h" : "O.OO..",
+    "i" : ".OO...", "j" : ".OOO..", "k" : "O...O.",
+    "l" : "O.O.O.", "m" : "OO..O.", "n" : "OO.OO.",
+    "o" : "O..OO.", "p" : "OOO.O.", "q" : "OOOOO.",
+    "r" : "O.OOO.", "s" : ".OO.O.", "t" : ".OOOO.",
+    "u" : "O...OO", "v" : "O.O.OO", "w" : ".OOO.O",
+    "x" : "OO..OO", "y" : "OO.OOO", "z" : "O..OOO",
+    CAPITAL : CAPITAL_FOLLOWS, 
+    NUMBER  : NUMBER_FOLLOWS
 }
 BRAILLE_TO_ENGLISH : Dict[str, str] = {value: key for key, value in ENGLISH_TO_BRAILLE.items()}
 
 # Braille number to letter mapping
 NUMBERS_TO_LETTERS : Dict[str, str] = {
-    "1" : "a",
-    "2" : "b",
-    "3" : "c",
-    "4" : "d",
-    "5" : "e",
-    "6" : "f",
-    "7" : "g",
-    "8" : "h",
-    "9" : "i",
-    "0" : "j"
+    "1" : "a", "2" : "b", "3" : "c", "4" : "d", "5" : "e",
+    "6" : "f", "7" : "g", "8" : "h", "9" : "i", "0" : "j"
 }
 LETTERS_TO_NUMBERS : Dict[str, str] = {value: key for key, value in NUMBERS_TO_LETTERS.items()}

--- a/python/constants.py
+++ b/python/constants.py
@@ -1,0 +1,69 @@
+from typing import Dict, Frozenset
+
+# Language constants
+ENGLISH : str = "english"
+BRAILLE : str = "braille"
+CAPITAL : str = "capital"
+NUMBER  : str = "number"
+
+# Braille language constants
+BRAILLE_CAPITAL_MODIFIER : str = ".....O"
+BRAILLE_NUMBER_MODIFIER  : str = ".O.OOO"
+
+# Error messages
+INVALID_INPUT_MSG    : str = "Invalid input.\nOnly alphanumeric characters and spaces are allowed for english.\nOnly supported sequences of '.' and 'O' are allowed for braille. Refer to the project README for a description of supported braille characters."
+INVALID_CHAR_SEQ_MSG : str = "Invalid character sequence.\nNumerical characters must be followed by a space or another numerical character.\nCapital characters must be followed by an alphabetical character.\nBraille sequences cannot end with a capital or number modifier."
+
+# Character sets
+PERMITTED_NON_ALPHANUMERIC_CHARS : Frozenset[str] = frozenset([" "])
+PERMITTED_MODIFIERS              : Frozenset[str] = frozenset([CAPITAL, NUMBER])
+NUMBER_TERMINATING_CHARS         : Frozenset[str] = frozenset([" "])
+
+# Translation dictionaries
+ENGLISH_TO_BRAILLE : Dict[str, str] = {
+    " "     : "......",
+    "a"     : "O.....",
+    "b"     : "O.O...",
+    "c"     : "OO....",
+    "d"     : "OO.O..",
+    "e"     : "O..O..",
+    "f"     : "OOO...",
+    "g"     : "OOOO..",
+    "h"     : "O.OO..",
+    "i"     : ".OO...",
+    "j"     : ".OOO..",
+    "k"     : "O...O.",
+    "l"     : "O.O.O.",
+    "m"     : "OO..O.",
+    "n"     : "OO.OO.",
+    "o"     : "O..OO.",
+    "p"     : "OOO.O.",
+    "q"     : "OOOOO.",
+    "r"     : "O.OOO.",
+    "s"     : ".OO.O.",
+    "t"     : ".OOOO.",
+    "u"     : "O...OO",
+    "v"     : "O.O.OO",
+    "w"     : ".OOO.O",
+    "x"     : "OO..OO",
+    "y"     : "OO.OOO",
+    "z"     : "O..OOO",
+    CAPITAL : BRAILLE_CAPITAL_MODIFIER,
+    NUMBER  : BRAILLE_NUMBER_MODIFIER
+}
+BRAILLE_TO_ENGLISH : Dict[str, str] = {value: key for key, value in ENGLISH_TO_BRAILLE.items()}
+
+# Braille number to letter mapping
+NUMBERS_TO_LETTERS : Dict[str, str] = {
+    "1" : "a",
+    "2" : "b",
+    "3" : "c",
+    "4" : "d",
+    "5" : "e",
+    "6" : "f",
+    "7" : "g",
+    "8" : "h",
+    "9" : "i",
+    "0" : "j"
+}
+LETTERS_TO_NUMBERS : Dict[str, str] = {value: key for key, value in NUMBERS_TO_LETTERS.items()}

--- a/python/mark_translator.test.py
+++ b/python/mark_translator.test.py
@@ -1,0 +1,79 @@
+import unittest
+import subprocess
+
+from constants import *
+
+class TestTranslator(unittest.TestCase):
+    # Convert a string to Braille and back to the original string
+    def perform_bijection_test(self, input: str):
+        # Command to run translator.py script
+        command = ["python3", "translator.py", input.strip()]
+        result = subprocess.run(command, capture_output=True, text=True)
+
+        reverse_command = ["python3", "translator.py", result.stdout.strip()]
+        result = subprocess.run(reverse_command, capture_output=True, text=True)
+        
+        # Strip any leading/trailing whitespace from the output and ensure it matches the initial input
+        self.assertEqual(result.stdout.strip(), input)
+
+    def test_valid_bijections(self):
+        test_strings = [
+            "Abc",
+            "123",
+            "xYz",
+            "HAHAHAAA",
+            "abcdefghijklmnopqrstuvwxyz",
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+            "1234567890",
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
+            "a b c d e f g h i j k l m n o p q r s t u v w x y z",
+            "1 2 3 4 5 6 7 8 9 0",
+            "A B C D E F G H I J K L M N O P Q R S T U V W X Y Z",
+            "A B C D E F G H I J K L M N O P Q R S T U V W X Y Z 1 2 3 4 5 6 7 8 9 0",
+            "a b c d e f g h i j k l m n o p q r s t u v w x y z 1 2 3 4 5 6 7 8 9 0 A B C D E F G H I J K L M N O P Q R S T U V W X Y Z",
+            "a123 b456 c789 d0 e1 f2 g3 h4 i5 j6 k7 l8 m9 n0 o1 p2 q3 r4 s5 t6 u7 v8 w9 x0 y1 z2",
+        ]
+
+        for test_string in test_strings:
+            self.perform_bijection_test(test_string)
+
+    def test_invalid_input(self):
+        invalid_inputs = [
+            "abc!",
+            "@",
+            "123.456",
+            "O.OOOA",
+            "A4C",
+            "2A",
+            "OOOOOOOOOOO.",
+            ".O...O",
+            "O.O.O",
+            BRAILLE_CAPITAL_MODIFIER,
+            BRAILLE_NUMBER_MODIFIER,
+            BRAILLE_NUMBER_MODIFIER + BRAILLE_CAPITAL_MODIFIER + ENGLISH_TO_BRAILLE["k"],
+            BRAILLE_CAPITAL_MODIFIER + BRAILLE_NUMBER_MODIFIER + ENGLISH_TO_BRAILLE["a"],
+            BRAILLE_CAPITAL_MODIFIER + " ",
+            BRAILLE_NUMBER_MODIFIER + ENGLISH_TO_BRAILLE["k"],
+            BRAILLE_NUMBER_MODIFIER + ENGLISH_TO_BRAILLE[" "],
+            BRAILLE_CAPITAL_MODIFIER + ENGLISH_TO_BRAILLE[" "],
+        ]
+
+        for invalid_input in invalid_inputs:
+            result = subprocess.run(["python3", "translator.py", invalid_input], capture_output=True, text=True)
+            self.assertFalse(result.returncode == 0, f"Invalid input '{invalid_input}' was accepted.")
+
+    def test_output(self):
+        # Command to run translator.py script
+        command = ["python3", "translator.py", "Abc", "123", "xYz"]
+        
+        # Run the command and capture output
+        result = subprocess.run(command, capture_output=True, text=True)
+        
+        # Expected output without the newline at the end
+        expected_output = ".....OO.....O.O...OO...........O.OOOO.....O.O...OO..........OO..OO.....OOO.OOOO..OOO"
+        
+        # Strip any leading/trailing whitespace from the output and compare
+        self.assertEqual(result.stdout.strip(), expected_output)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/mark_translator.test.py
+++ b/python/mark_translator.test.py
@@ -48,14 +48,14 @@ class TestTranslator(unittest.TestCase):
             "OOOOOOOOOOO.",
             ".O...O",
             "O.O.O",
-            BRAILLE_CAPITAL_MODIFIER,
-            BRAILLE_NUMBER_MODIFIER,
-            BRAILLE_NUMBER_MODIFIER + BRAILLE_CAPITAL_MODIFIER + ENGLISH_TO_BRAILLE["k"],
-            BRAILLE_CAPITAL_MODIFIER + BRAILLE_NUMBER_MODIFIER + ENGLISH_TO_BRAILLE["a"],
-            BRAILLE_CAPITAL_MODIFIER + " ",
-            BRAILLE_NUMBER_MODIFIER + ENGLISH_TO_BRAILLE["k"],
-            BRAILLE_NUMBER_MODIFIER + ENGLISH_TO_BRAILLE[" "],
-            BRAILLE_CAPITAL_MODIFIER + ENGLISH_TO_BRAILLE[" "],
+            CAPITAL_FOLLOWS,
+            NUMBER_FOLLOWS,
+            NUMBER_FOLLOWS + CAPITAL_FOLLOWS + ENGLISH_TO_BRAILLE["k"],
+            CAPITAL_FOLLOWS + NUMBER_FOLLOWS + ENGLISH_TO_BRAILLE["a"],
+            CAPITAL_FOLLOWS + " ",
+            NUMBER_FOLLOWS + ENGLISH_TO_BRAILLE["k"],
+            NUMBER_FOLLOWS + ENGLISH_TO_BRAILLE[" "],
+            CAPITAL_FOLLOWS + ENGLISH_TO_BRAILLE[" "],
         ]
 
         for invalid_input in invalid_inputs:

--- a/python/translator.py
+++ b/python/translator.py
@@ -3,7 +3,6 @@ from constants import *
 
 import sys
 
-
 def validate_english_char(char: str, next_is_number: bool) -> None:
     """
     Validates an English character based on the given conditions.
@@ -21,7 +20,6 @@ def validate_english_char(char: str, next_is_number: bool) -> None:
     elif next_is_number and not (char.isnumeric() or char in NUMBER_TERMINATING_CHARS):
         # Non-numeric, non-terminating character immediately following a number character
         raise ValueError(INVALID_CHAR_SEQ_MSG)
-
 
 def english_to_braille(text: str) -> str:
     """
@@ -57,7 +55,6 @@ def english_to_braille(text: str) -> str:
 
     return "".join(braille_chars)
 
-
 def validate_braille_char(char: str, prev_char: str, is_last: bool, next_is_capital: bool, next_is_number: bool) -> None:
     """
     Validates a Braille character based on the given conditions.
@@ -89,7 +86,6 @@ def validate_braille_char(char: str, prev_char: str, is_last: bool, next_is_capi
     elif prev_char == BRAILLE_NUMBER_MODIFIER and english_char in NUMBER_TERMINATING_CHARS:
         # Number character immediately followed by a number-terminating character
         raise ValueError(INVALID_CHAR_SEQ_MSG)
-
 
 def braille_to_english(text: str) -> str:
     """
@@ -128,7 +124,6 @@ def braille_to_english(text: str) -> str:
 
     return "".join(english_chars)
 
-
 def detect_language(text: str) -> str:
     """
     Detects the language of the given text.
@@ -141,7 +136,6 @@ def detect_language(text: str) -> str:
     """
     # Braille text has a length that is a multiple of 6 and contains a '.' character
     return BRAILLE if (len(text) % 6 == 0 and "." in text) else ENGLISH
-
 
 def process_args(args: List[str]) -> str:
     """
@@ -158,7 +152,6 @@ def process_args(args: List[str]) -> str:
     
     return " ".join(args)
 
-
 def main():
     args = sys.argv[1:]
 
@@ -167,7 +160,6 @@ def main():
         print(braille_to_english(input_text))
     else:
         print(english_to_braille(input_text))
-
 
 if __name__ == "__main__":
     main()

--- a/python/translator.py
+++ b/python/translator.py
@@ -1,96 +1,26 @@
 from typing import List
+from constants import *
+
 import sys
 
-ENGLISH = "english"
-BRAILLE = "braille"
-CAPITAL = "capital"
-NUMBER  = "number"
 
-BRAILLE_CAPITAL = ".....O"
-BRAILLE_NUMBER  = ".O.OOO"
-
-INVALID_INPUT_MSG = "Invalid input. Only alphanumeric characters and spaces are allowed for english. Only '.' and 'O' are allowed for braille."
-
-PERMITTED_NON_ALPHANUMERIC_CHARS = set([" "])
-PERMITTED_MODIFIERS              = set([CAPITAL, NUMBER])
-NUMBER_TERMINATING_CHARS         = set([" "])
-
-ENGLISH_TO_BRAILLE = {
-    " "     : "......",
-    "a"     : "O.....",
-    "b"     : "O.O...",
-    "c"     : "OO....",
-    "d"     : "OO.O..",
-    "e"     : "O..O..",
-    "f"     : "OOO...",
-    "g"     : "OOOO..",
-    "h"     : "O.OO..",
-    "i"     : ".OO...",
-    "j"     : ".OOO..",
-    "k"     : "O...O.",
-    "l"     : "O.O.O.",
-    "m"     : "OO..O.",
-    "n"     : "OO.OO.",
-    "o"     : "O..OO.",
-    "p"     : "OOO.O.",
-    "q"     : "OOOOO.",
-    "r"     : "O.OOO.",
-    "s"     : ".OO.O.",
-    "t"     : ".OOOO.",
-    "u"     : "O...OO",
-    "v"     : "O.O.OO",
-    "w"     : ".OOO.O",
-    "x"     : "OO..OO",
-    "y"     : "OO.OOO",
-    "z"     : "O..OOO",
-    CAPITAL : BRAILLE_CAPITAL,
-    NUMBER  : BRAILLE_NUMBER
-}
-BRAILLE_TO_ENGLISH = {value: key for key, value in ENGLISH_TO_BRAILLE.items()}
-
-NUMBERS_TO_LETTERS = {
-    "1" : "a",
-    "2" : "b",
-    "3" : "c",
-    "4" : "d",
-    "5" : "e",
-    "6" : "f",
-    "7" : "g",
-    "8" : "h",
-    "9" : "i",
-    "0" : "j"
-}
-LETTERS_TO_NUMBERS = {value: key for key, value in NUMBERS_TO_LETTERS.items()}
-
-
-def process_args(args: List[str]) -> str:
+def validate_english_char(char: str, next_is_number: bool) -> None:
     """
-    Process the input arguments to form a single string.
+    Validates an English character based on the given conditions.
     
     Args:
-        args (List[str]): List of input arguments.
+        char (str): The character to validate.
+        next_is_number (bool): Indicates if the next character follows a braille number character.
     
-    Returns:
-        str: The input arguments joined as a single string.
+    Raises:
+        ValueError: If the character is invalid.
     """
-    if len(args) == 0:
-        raise ValueError(f"Usage: python3 translator.py {'<text>'}")
-    
-    return " ".join(args)
-
-
-def detect_language(text: str) -> str:
-    """
-    Detects the language of the given text.
-    
-    Args:
-        text (str): The input text.
-    
-    Returns:
-        str: The detected language ("english" or "braille").
-    """
-    # Braille text has a length that is a multiple of 6 and contains a '.' character
-    return BRAILLE if (len(text) % 6 == 0 and "." in text) else ENGLISH
+    if not (char.isalnum() or char in PERMITTED_NON_ALPHANUMERIC_CHARS):
+        # Invalid character
+        raise ValueError(INVALID_INPUT_MSG)
+    elif next_is_number and not (char.isnumeric() or char in NUMBER_TERMINATING_CHARS):
+        # Non-numeric, non-terminating character immediately following a number character
+        raise ValueError(INVALID_CHAR_SEQ_MSG)
 
 
 def english_to_braille(text: str) -> str:
@@ -115,74 +45,17 @@ def english_to_braille(text: str) -> str:
         if char.isnumeric():
             if not next_is_number:
                 # Append the braille number character before the first digit of a number
-                braille_chars.append(ENGLISH_TO_BRAILLE[NUMBER])
+                braille_chars.append(BRAILLE_NUMBER_MODIFIER)
                 next_is_number = True
             char = NUMBERS_TO_LETTERS[char]
         elif char.isupper():
-            braille_chars.append(ENGLISH_TO_BRAILLE[CAPITAL])
+            braille_chars.append(BRAILLE_CAPITAL_MODIFIER)
             # Convert the character to lowercase for braille mapping
             char = char.lower()
 
         braille_chars.append(ENGLISH_TO_BRAILLE[char])
 
     return "".join(braille_chars)
-
-
-def validate_english_char(char: str, next_is_number: bool) -> None:
-    """
-    Validates an English character based on the given conditions.
-    
-    Args:
-        char (str): The character to validate.
-        next_is_number (bool): Indicates if the next character follows a braille number character.
-    
-    Raises:
-        ValueError: If the character is invalid.
-    """
-    if not (char.isalnum() or char in PERMITTED_NON_ALPHANUMERIC_CHARS):
-        # Invalid character
-        raise ValueError(INVALID_INPUT_MSG)
-    elif next_is_number and not (char.isnumeric() or char in NUMBER_TERMINATING_CHARS):
-        # Non-numeric, non-terminating character immediately following a number character
-        raise ValueError(INVALID_INPUT_MSG)
-
-
-def braille_to_english(text: str) -> str:
-    """
-    Converts Braille text to English.
-    
-    Args:
-        text (str): The input Braille text.
-    
-    Returns:
-        str: The English representation of the input text.
-    """
-    english_chars = []
-
-    next_is_capital = False  # Indicates if the previous character was a braille capital character
-    next_is_number = False  # Indicates if the character follows a braille number character
-    for i in range(0, len(text), 6):
-        braille_char = text[i:i+6]
-        validate_braille_char(braille_char, text[i-6:i] if i > 0 else "", i + 6 == len(text), next_is_capital, next_is_number)
-
-        english_char = BRAILLE_TO_ENGLISH[braille_char]
-        if braille_char == ENGLISH_TO_BRAILLE[CAPITAL]:
-            next_is_capital = True
-        elif braille_char == ENGLISH_TO_BRAILLE[NUMBER]:
-            next_is_number = True
-        else:
-            if next_is_capital:
-                english_char = english_char.upper()
-                next_is_capital = False
-            elif next_is_number:
-                if english_char in NUMBER_TERMINATING_CHARS:
-                    next_is_number = False
-                else:
-                    english_char = LETTERS_TO_NUMBERS[english_char]
-
-            english_chars.append(english_char)
-
-    return "".join(english_chars)
 
 
 def validate_braille_char(char: str, prev_char: str, is_last: bool, next_is_capital: bool, next_is_number: bool) -> None:
@@ -206,17 +79,85 @@ def validate_braille_char(char: str, prev_char: str, is_last: bool, next_is_capi
     english_char = BRAILLE_TO_ENGLISH[char]
     if is_last and english_char in PERMITTED_MODIFIERS:
         # Capital or number character as the last character
-        raise ValueError(INVALID_INPUT_MSG)
+        raise ValueError(INVALID_CHAR_SEQ_MSG)
     elif next_is_capital and english_char in PERMITTED_NON_ALPHANUMERIC_CHARS:
         # Non-alphanumeric character after a capital character
-        raise ValueError(INVALID_INPUT_MSG)
+        raise ValueError(INVALID_CHAR_SEQ_MSG)
     elif next_is_number and english_char not in LETTERS_TO_NUMBERS and not english_char in NUMBER_TERMINATING_CHARS:
         # Non-numeric, non-terminating character where a numeric or number-terminating character is expected
-        raise ValueError(INVALID_INPUT_MSG)
-    elif prev_char == ENGLISH_TO_BRAILLE[NUMBER] and english_char in NUMBER_TERMINATING_CHARS:
+        raise ValueError(INVALID_CHAR_SEQ_MSG)
+    elif prev_char == BRAILLE_NUMBER_MODIFIER and english_char in NUMBER_TERMINATING_CHARS:
         # Number character immediately followed by a number-terminating character
-        raise ValueError(INVALID_INPUT_MSG)
+        raise ValueError(INVALID_CHAR_SEQ_MSG)
+
+
+def braille_to_english(text: str) -> str:
+    """
+    Converts Braille text to English.
     
+    Args:
+        text (str): The input Braille text.
+    
+    Returns:
+        str: The English representation of the input text.
+    """
+    english_chars = []
+
+    next_is_capital = False  # Indicates if the previous character was a braille capital character
+    next_is_number = False  # Indicates if the character follows a braille number character
+    for i in range(0, len(text), 6):
+        braille_char = text[i:i+6]
+        validate_braille_char(braille_char, text[i-6:i] if i > 0 else "", i + 6 == len(text), next_is_capital, next_is_number)
+
+        english_char = BRAILLE_TO_ENGLISH[braille_char]
+        if braille_char == BRAILLE_CAPITAL_MODIFIER:
+            next_is_capital = True
+        elif braille_char == BRAILLE_NUMBER_MODIFIER:
+            next_is_number = True
+        else:
+            if next_is_capital:
+                english_char = english_char.upper()
+                next_is_capital = False
+            elif next_is_number:
+                if english_char in NUMBER_TERMINATING_CHARS:
+                    next_is_number = False
+                else:
+                    english_char = LETTERS_TO_NUMBERS[english_char]
+
+            english_chars.append(english_char)
+
+    return "".join(english_chars)
+
+
+def detect_language(text: str) -> str:
+    """
+    Detects the language of the given text.
+    
+    Args:
+        text (str): The input text.
+    
+    Returns:
+        str: The detected language ("english" or "braille").
+    """
+    # Braille text has a length that is a multiple of 6 and contains a '.' character
+    return BRAILLE if (len(text) % 6 == 0 and "." in text) else ENGLISH
+
+
+def process_args(args: List[str]) -> str:
+    """
+    Process the input arguments to form a single string.
+    
+    Args:
+        args (List[str]): List of input arguments.
+    
+    Returns:
+        str: The input arguments joined as a single string.
+    """
+    if len(args) == 0:
+        raise ValueError(f"Usage: python3 translator.py {'<text>'}")
+    
+    return " ".join(args)
+
 
 def main():
     args = sys.argv[1:]

--- a/python/translator.py
+++ b/python/translator.py
@@ -43,11 +43,11 @@ def english_to_braille(text: str) -> str:
         if char.isnumeric():
             if not next_is_number:
                 # Append the braille number character before the first digit of a number
-                braille_chars.append(BRAILLE_NUMBER_MODIFIER)
+                braille_chars.append(NUMBER_FOLLOWS)
                 next_is_number = True
             char = NUMBERS_TO_LETTERS[char]
         elif char.isupper():
-            braille_chars.append(BRAILLE_CAPITAL_MODIFIER)
+            braille_chars.append(CAPITAL_FOLLOWS)
             # Convert the character to lowercase for braille mapping
             char = char.lower()
 
@@ -83,7 +83,7 @@ def validate_braille_char(char: str, prev_char: str, is_last: bool, next_is_capi
     elif next_is_number and english_char not in LETTERS_TO_NUMBERS and not english_char in NUMBER_TERMINATING_CHARS:
         # Non-numeric, non-terminating character where a numeric or number-terminating character is expected
         raise ValueError(INVALID_CHAR_SEQ_MSG)
-    elif prev_char == BRAILLE_NUMBER_MODIFIER and english_char in NUMBER_TERMINATING_CHARS:
+    elif prev_char == NUMBER_FOLLOWS and english_char in NUMBER_TERMINATING_CHARS:
         # Number character immediately followed by a number-terminating character
         raise ValueError(INVALID_CHAR_SEQ_MSG)
 
@@ -106,9 +106,9 @@ def braille_to_english(text: str) -> str:
         validate_braille_char(braille_char, text[i-6:i] if i > 0 else "", i + 6 == len(text), next_is_capital, next_is_number)
 
         english_char = BRAILLE_TO_ENGLISH[braille_char]
-        if braille_char == BRAILLE_CAPITAL_MODIFIER:
+        if braille_char == CAPITAL_FOLLOWS:
             next_is_capital = True
-        elif braille_char == BRAILLE_NUMBER_MODIFIER:
+        elif braille_char == NUMBER_FOLLOWS:
             next_is_number = True
         else:
             if next_is_capital:

--- a/python/translator.py
+++ b/python/translator.py
@@ -80,7 +80,7 @@ def validate_braille_char(char: str, prev_char: str, is_last: bool, next_is_capi
     if is_last and english_char in PERMITTED_MODIFIERS:
         # Capital or number character as the last character
         raise ValueError(INVALID_CHAR_SEQ_MSG)
-    elif next_is_capital and english_char in PERMITTED_NON_ALPHANUMERIC_CHARS:
+    elif next_is_capital and (english_char in PERMITTED_NON_ALPHANUMERIC_CHARS or english_char in PERMITTED_MODIFIERS):
         # Non-alphanumeric character after a capital character
         raise ValueError(INVALID_CHAR_SEQ_MSG)
     elif next_is_number and english_char not in LETTERS_TO_NUMBERS and not english_char in NUMBER_TERMINATING_CHARS:

--- a/python/translator.py
+++ b/python/translator.py
@@ -1,1 +1,171 @@
+import sys
 
+ENGLISH = "english"
+BRAILLE = "braille"
+CAPITAL = "capital"
+NUMBER  = "number"
+
+INVALID_INPUT_MSG = "Invalid input. Only alphanumeric characters and spaces are allowed for english. Only '.' and 'O' are allowed for braille."
+
+PERMITTED_NON_ALPHANUMERIC_CHARS = set([" "])
+PERMITTED_MODIFIERS              = set([CAPITAL, NUMBER])
+NUMBER_TERMINATING_CHARS         = set([" "])
+
+ENGLISH_TO_BRAILLE = {
+    " "     : "......",
+    "a"     : "O.....",
+    "b"     : "O.O...",
+    "c"     : "OO....",
+    "d"     : "OO.O..",
+    "e"     : "O..O..",
+    "f"     : "OOO...",
+    "g"     : "OOOO..",
+    "h"     : "O.OO..",
+    "i"     : ".OO...",
+    "j"     : ".OOO..",
+    "k"     : "O...O.",
+    "l"     : "O.O.O.",
+    "m"     : "OO..O.",
+    "n"     : "OO.OO.",
+    "o"     : "O..OO.",
+    "p"     : "OOO.O.",
+    "q"     : "OOOOO.",
+    "r"     : "O.OOO.",
+    "s"     : ".OO.O.",
+    "t"     : ".OOOO.",
+    "u"     : "O...OO",
+    "v"     : "O.O.OO",
+    "w"     : ".OOO.O",
+    "x"     : "OO..OO",
+    "y"     : "OO.OOO",
+    "z"     : "O..OOO",
+    CAPITAL : ".....O",
+    NUMBER  : ".O.OOO"
+}
+BRAILLE_TO_ENGLISH = {value: key for key, value in ENGLISH_TO_BRAILLE.items()}
+
+NUMBERS_TO_LETTERS = {
+    "1" : "a",
+    "2" : "b",
+    "3" : "c",
+    "4" : "d",
+    "5" : "e",
+    "6" : "f",
+    "7" : "g",
+    "8" : "h",
+    "9" : "i",
+    "0" : "j"
+}
+LETTERS_TO_NUMBERS = {value: key for key, value in NUMBERS_TO_LETTERS.items()}
+
+
+def process_args(args: list[str]) -> str:
+    if len(args) == 0:
+        print("Usage: python3 translator.py <text>")
+        sys.exit(1)
+
+    input_text = " ".join(args)
+    return input_text
+
+
+def detect_language(text: str) -> str:
+    return BRAILLE if (len(text) % 6 == 0 and "." in text) else ENGLISH
+
+
+def english_to_braille(text: str) -> str:
+    braille_chars = []
+
+    next_is_number = False
+    for char in text:
+        validate_english_char(char, next_is_number)
+
+        if char in NUMBER_TERMINATING_CHARS:
+            next_is_number = False
+        
+        if char.isnumeric():
+            if not next_is_number:
+                braille_chars.append(ENGLISH_TO_BRAILLE[NUMBER])
+                next_is_number = True
+            char = NUMBERS_TO_LETTERS[char]
+        elif char.isupper():
+            braille_chars.append(ENGLISH_TO_BRAILLE[CAPITAL])
+            char = char.lower()
+
+        braille_chars.append(ENGLISH_TO_BRAILLE[char])
+
+    return "".join(braille_chars)
+
+
+def validate_english_char(char: str, next_is_number: bool) -> None:
+    if not (char.isalnum() or char in PERMITTED_NON_ALPHANUMERIC_CHARS):
+        # Invalid character
+        print(INVALID_INPUT_MSG)
+        sys.exit(1)
+    elif next_is_number and not (char.isnumeric() or char in NUMBER_TERMINATING_CHARS):
+        # Non-numeric, non-terminating character immediately following a number character
+        print(INVALID_INPUT_MSG)
+        sys.exit(1)
+
+
+def braille_to_english(text: str) -> str:
+    english_chars = []
+
+    next_is_capital = False
+    next_is_number = False
+    for i in range(0, len(text), 6):
+        braille_char = text[i:i+6]
+        validate_braille_char(braille_char, text[i-6:i] if i > 0 else "", i + 6 == len(text), next_is_capital, next_is_number)
+
+        english_char = BRAILLE_TO_ENGLISH[braille_char]
+        if braille_char == ENGLISH_TO_BRAILLE[CAPITAL]:
+            next_is_capital = True
+        elif braille_char == ENGLISH_TO_BRAILLE[NUMBER]:
+            next_is_number = True
+        else:
+            if next_is_capital:
+                english_char = english_char.upper()
+                next_is_capital = False
+            elif next_is_number:
+                if english_char in NUMBER_TERMINATING_CHARS:
+                    next_is_number = False
+                else:
+                    english_char = LETTERS_TO_NUMBERS[english_char]
+
+            english_chars.append(english_char)
+
+    return "".join(english_chars)
+
+
+def validate_braille_char(char: str, prev_char: str, is_last: bool, next_is_capital: bool, next_is_number: bool) -> None:
+    if char not in BRAILLE_TO_ENGLISH:
+        # Invalid braille character
+        print(INVALID_INPUT_MSG)
+        sys.exit(1)
+
+    english_char = BRAILLE_TO_ENGLISH[char]
+    if is_last and english_char in PERMITTED_MODIFIERS:
+        # Capital or number character as the last character
+        print(INVALID_INPUT_MSG)
+        sys.exit(1)
+    elif next_is_capital and english_char in PERMITTED_NON_ALPHANUMERIC_CHARS:
+        # Non-alphanumeric character after a capital character
+        print(INVALID_INPUT_MSG)
+        sys.exit(1)
+    elif next_is_number and english_char not in LETTERS_TO_NUMBERS and not english_char in NUMBER_TERMINATING_CHARS:
+        # Non-numeric, non-terminating character where a numeric or number-terminating character is expected
+        print(INVALID_INPUT_MSG)
+        sys.exit(1)
+    elif prev_char == ENGLISH_TO_BRAILLE[NUMBER] and english_char in NUMBER_TERMINATING_CHARS:
+        # Number character immediately followed by a number-terminating character
+        print(INVALID_INPUT_MSG)
+        sys.exit(1)
+    
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+
+    input_text = process_args(args)
+    if detect_language(input_text) == BRAILLE:
+        print(braille_to_english(input_text))
+    else:
+        print(english_to_braille(input_text))

--- a/python/translator.py
+++ b/python/translator.py
@@ -1,9 +1,13 @@
+from typing import List
 import sys
 
 ENGLISH = "english"
 BRAILLE = "braille"
 CAPITAL = "capital"
 NUMBER  = "number"
+
+BRAILLE_CAPITAL = ".....O"
+BRAILLE_NUMBER  = ".O.OOO"
 
 INVALID_INPUT_MSG = "Invalid input. Only alphanumeric characters and spaces are allowed for english. Only '.' and 'O' are allowed for braille."
 
@@ -39,8 +43,8 @@ ENGLISH_TO_BRAILLE = {
     "x"     : "OO..OO",
     "y"     : "OO.OOO",
     "z"     : "O..OOO",
-    CAPITAL : ".....O",
-    NUMBER  : ".O.OOO"
+    CAPITAL : BRAILLE_CAPITAL,
+    NUMBER  : BRAILLE_NUMBER
 }
 BRAILLE_TO_ENGLISH = {value: key for key, value in ENGLISH_TO_BRAILLE.items()}
 
@@ -59,23 +63,49 @@ NUMBERS_TO_LETTERS = {
 LETTERS_TO_NUMBERS = {value: key for key, value in NUMBERS_TO_LETTERS.items()}
 
 
-def process_args(args: list[str]) -> str:
+def process_args(args: List[str]) -> str:
+    """
+    Process the input arguments to form a single string.
+    
+    Args:
+        args (List[str]): List of input arguments.
+    
+    Returns:
+        str: The input arguments joined as a single string.
+    """
     if len(args) == 0:
-        print("Usage: python3 translator.py <text>")
-        sys.exit(1)
-
-    input_text = " ".join(args)
-    return input_text
+        raise ValueError(f"Usage: python3 translator.py {'<text>'}")
+    
+    return " ".join(args)
 
 
 def detect_language(text: str) -> str:
+    """
+    Detects the language of the given text.
+    
+    Args:
+        text (str): The input text.
+    
+    Returns:
+        str: The detected language ("english" or "braille").
+    """
+    # Braille text has a length that is a multiple of 6 and contains a '.' character
     return BRAILLE if (len(text) % 6 == 0 and "." in text) else ENGLISH
 
 
 def english_to_braille(text: str) -> str:
+    """
+    Converts English text to Braille.
+    
+    Args:
+        text (str): The input English text.
+    
+    Returns:
+        str: The Braille representation of the input text.
+    """
     braille_chars = []
 
-    next_is_number = False
+    next_is_number = False  # Indicates if the next character follows a braille number character
     for char in text:
         validate_english_char(char, next_is_number)
 
@@ -84,11 +114,13 @@ def english_to_braille(text: str) -> str:
         
         if char.isnumeric():
             if not next_is_number:
+                # Append the braille number character before the first digit of a number
                 braille_chars.append(ENGLISH_TO_BRAILLE[NUMBER])
                 next_is_number = True
             char = NUMBERS_TO_LETTERS[char]
         elif char.isupper():
             braille_chars.append(ENGLISH_TO_BRAILLE[CAPITAL])
+            # Convert the character to lowercase for braille mapping
             char = char.lower()
 
         braille_chars.append(ENGLISH_TO_BRAILLE[char])
@@ -97,21 +129,38 @@ def english_to_braille(text: str) -> str:
 
 
 def validate_english_char(char: str, next_is_number: bool) -> None:
+    """
+    Validates an English character based on the given conditions.
+    
+    Args:
+        char (str): The character to validate.
+        next_is_number (bool): Indicates if the next character follows a braille number character.
+    
+    Raises:
+        ValueError: If the character is invalid.
+    """
     if not (char.isalnum() or char in PERMITTED_NON_ALPHANUMERIC_CHARS):
         # Invalid character
-        print(INVALID_INPUT_MSG)
-        sys.exit(1)
+        raise ValueError(INVALID_INPUT_MSG)
     elif next_is_number and not (char.isnumeric() or char in NUMBER_TERMINATING_CHARS):
         # Non-numeric, non-terminating character immediately following a number character
-        print(INVALID_INPUT_MSG)
-        sys.exit(1)
+        raise ValueError(INVALID_INPUT_MSG)
 
 
 def braille_to_english(text: str) -> str:
+    """
+    Converts Braille text to English.
+    
+    Args:
+        text (str): The input Braille text.
+    
+    Returns:
+        str: The English representation of the input text.
+    """
     english_chars = []
 
-    next_is_capital = False
-    next_is_number = False
+    next_is_capital = False  # Indicates if the previous character was a braille capital character
+    next_is_number = False  # Indicates if the character follows a braille number character
     for i in range(0, len(text), 6):
         braille_char = text[i:i+6]
         validate_braille_char(braille_char, text[i-6:i] if i > 0 else "", i + 6 == len(text), next_is_capital, next_is_number)
@@ -137,31 +186,39 @@ def braille_to_english(text: str) -> str:
 
 
 def validate_braille_char(char: str, prev_char: str, is_last: bool, next_is_capital: bool, next_is_number: bool) -> None:
+    """
+    Validates a Braille character based on the given conditions.
+    
+    Args:
+        char (str): The character to validate.
+        prev_char (str): The previous character.
+        is_last (bool): Indicates if the character is the last one.
+        next_is_capital (bool): Indicates if the next character is a capital letter.
+        next_is_number (bool): Indicates if the next character is a number.
+    
+    Raises:
+        ValueError: If the character is invalid.
+    """
     if char not in BRAILLE_TO_ENGLISH:
         # Invalid braille character
-        print(INVALID_INPUT_MSG)
-        sys.exit(1)
+        raise ValueError(INVALID_INPUT_MSG)
 
     english_char = BRAILLE_TO_ENGLISH[char]
     if is_last and english_char in PERMITTED_MODIFIERS:
         # Capital or number character as the last character
-        print(INVALID_INPUT_MSG)
-        sys.exit(1)
+        raise ValueError(INVALID_INPUT_MSG)
     elif next_is_capital and english_char in PERMITTED_NON_ALPHANUMERIC_CHARS:
         # Non-alphanumeric character after a capital character
-        print(INVALID_INPUT_MSG)
-        sys.exit(1)
+        raise ValueError(INVALID_INPUT_MSG)
     elif next_is_number and english_char not in LETTERS_TO_NUMBERS and not english_char in NUMBER_TERMINATING_CHARS:
         # Non-numeric, non-terminating character where a numeric or number-terminating character is expected
-        print(INVALID_INPUT_MSG)
-        sys.exit(1)
+        raise ValueError(INVALID_INPUT_MSG)
     elif prev_char == ENGLISH_TO_BRAILLE[NUMBER] and english_char in NUMBER_TERMINATING_CHARS:
         # Number character immediately followed by a number-terminating character
-        print(INVALID_INPUT_MSG)
-        sys.exit(1)
+        raise ValueError(INVALID_INPUT_MSG)
     
 
-if __name__ == "__main__":
+def main():
     args = sys.argv[1:]
 
     input_text = process_args(args)
@@ -169,3 +226,7 @@ if __name__ == "__main__":
         print(braille_to_english(input_text))
     else:
         print(english_to_braille(input_text))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description
This PR contains my Python solution for the Braille Translator.

Changes in this PR:

- Implemented the Braille translator in ```translator.py```
- Created simple unit tests to ensure the program works as expected.

The following restrictions are enforced by the program:

- Based on the requirements laid out in the README, only letters ```a``` to ```z```, numbers ```0``` to ```9```, and ```spaces``` are supported. Other characters are not supported.
- Since all symbols following a ```number follows``` symbol are assumed to be numbers until the next ```space``` symbol, numbers are not allowed to be immediately followed by a non-numerical symbol other than a ```space```.
- The ```capital follows``` symbol must be immediately followed by a valid alphabetical braille symbol.
- Braille is not allowed to end with a ```number follows``` or ```capital follows``` symbol.